### PR TITLE
Implement support for "case object"

### DIFF
--- a/src/main/scala/leon/plugin/Extractors.scala
+++ b/src/main/scala/leon/plugin/Extractors.scala
@@ -123,6 +123,16 @@ trait Extractors {
       }
     }
 
+    object ExCaseObject {
+      def unapply(s: Select): Option[Symbol] = {
+        if (s.tpe.typeSymbol.isModuleClass) {
+          Some(s.tpe.typeSymbol)
+        } else {
+          None
+        }
+      }
+    }
+
     object ExCaseClassSyntheticJunk {
       def unapply(cd: ClassDef): Boolean = cd match {
         case ClassDef(_, _, _, _) if (cd.symbol.isSynthetic && cd.symbol.isFinal) => true

--- a/src/main/scala/leon/purescala/Definitions.scala
+++ b/src/main/scala/leon/purescala/Definitions.scala
@@ -253,6 +253,7 @@ object Definitions {
   class CaseClassDef(val id: Identifier, prnt: Option[AbstractClassDef] = None) extends ClassTypeDef with ExtractorTypeDef {
     private var parent_ = prnt
     var fields: VarDecls = Nil
+    var isCaseObject = false
     val isAbstract = false
 
     def setParent(newParent: AbstractClassDef) = {

--- a/src/main/scala/leon/purescala/PrettyPrinter.scala
+++ b/src/main/scala/leon/purescala/PrettyPrinter.scala
@@ -117,7 +117,11 @@ object PrettyPrinter {
     case CaseClass(cd, args) => {
       var nsb = sb
       nsb.append(cd.id)
-      nsb = ppNary(nsb, args, "(", ", ", ")", lvl)
+      if (cd.isCaseObject) {
+        nsb = ppNary(nsb, args, "", "", "", lvl)
+      } else {
+        nsb = ppNary(nsb, args, "(", ", ", ")", lvl)
+      }
       nsb
     }
     case CaseClassInstanceOf(cd, e) => {

--- a/src/main/scala/leon/purescala/ScalaPrinter.scala
+++ b/src/main/scala/leon/purescala/ScalaPrinter.scala
@@ -124,7 +124,11 @@ object ScalaPrinter {
 
     case CaseClass(cd, args) => {
       sb.append(cd.id)
-      ppNary(sb, args, "(", ", ", ")", lvl)
+      if (cd.isCaseObject) {
+        ppNary(sb, args, "", "", "", lvl)
+      } else {
+        ppNary(sb, args, "(", ", ", ")", lvl)
+      }
     }
     case CaseClassInstanceOf(cd, e) => {
       pp(e, sb, lvl)

--- a/src/test/resources/regression/verification/purescala/valid/CaseObject1.scala
+++ b/src/test/resources/regression/verification/purescala/valid/CaseObject1.scala
@@ -1,0 +1,21 @@
+object CaseObject1 {
+
+  abstract sealed class A
+  case class B(size: Int) extends A
+  case object C extends A
+
+  def foo(): A = {
+    C
+  }
+
+  def foo1(a: A): A = a match {
+    case C => a
+    case B(s) => a 
+  }
+
+  def foo2(a: A): A = a match {
+    case c @ C => c
+    case B(s) => a
+  }
+
+}


### PR DESCRIPTION
Support for the definition of case objects along with their usage.

``` scala
  case class Nil()

  def foo(): List = Nil()
```

becomes:

``` scala
  case object Nil

  def foo(): List = Nil
```
