### PR TITLE
Correct handling of choose in verification.

### DIFF
--- a/src/main/scala/leon/purescala/TreeOps.scala
+++ b/src/main/scala/leon/purescala/TreeOps.scala
@@ -361,6 +361,7 @@ object TreeOps {
     def combine(s1: Set[Identifier], s2: Set[Identifier]) = s1 ++ s2
     def compute(t: Expr, s: Set[Identifier]) = t match {
       case Let(i,_,_) => s -- Set(i)
+      case Choose(is,_) => s -- is
       case MatchExpr(_, cses) => s -- (cses.map(_.pattern.binders).foldLeft(Set[Identifier]())((a, b) => a ++ b))
       case _ => s
     }

--- a/src/test/resources/regression/verification/purescala/invalid/Choose1.scala
+++ b/src/test/resources/regression/verification/purescala/invalid/Choose1.scala
@@ -1,0 +1,39 @@
+import leon.Annotations._
+import leon.Utils._
+
+object Choose1 {
+    sealed abstract class List
+    case class Cons(head: Int, tail: List) extends List
+    case class Nil() extends List
+
+    def size(l: List) : Int = (l match {
+        case Nil() => 0
+        case Cons(_, t) => 1 + size(t)
+    }) ensuring(res => res >= 0)
+
+    def content(l: List) : Set[Int] = l match {
+      case Nil() => Set.empty[Int]
+      case Cons(x, xs) => Set(x) ++ content(xs)
+    }
+
+    def listOfSize(i: Int): List = {
+      require(i >= 0)
+
+      if (i == 0) {
+        Nil()
+      } else {
+        choose { (res: List) => size(res) == i-1 }
+      }
+    } ensuring ( size(_) == i )
+
+
+    def listOfSize2(i: Int): List = {
+      require(i >= 0)
+
+      if (i > 0) {
+        Cons(0, listOfSize(i-1))
+      } else {
+        Nil()
+      }
+    } ensuring ( size(_) == i )
+}

--- a/src/test/resources/regression/verification/purescala/valid/Choose1.scala
+++ b/src/test/resources/regression/verification/purescala/valid/Choose1.scala
@@ -1,0 +1,39 @@
+import leon.Annotations._
+import leon.Utils._
+
+object Choose1 {
+    sealed abstract class List
+    case class Cons(head: Int, tail: List) extends List
+    case class Nil() extends List
+
+    def size(l: List) : Int = (l match {
+        case Nil() => 0
+        case Cons(_, t) => 1 + size(t)
+    }) ensuring(res => res >= 0)
+
+    def content(l: List) : Set[Int] = l match {
+      case Nil() => Set.empty[Int]
+      case Cons(x, xs) => Set(x) ++ content(xs)
+    }
+
+    def listOfSize(i: Int): List = {
+      require(i >= 0)
+
+      if (i == 0) {
+        Nil()
+      } else {
+        choose { (res: List) => size(res) == i }
+      }
+    } ensuring ( size(_) == i )
+
+
+    def listOfSize2(i: Int): List = {
+      require(i >= 0)
+
+      if (i > 0) {
+        Cons(0, listOfSize(i-1))
+      } else {
+        Nil()
+      }
+    } ensuring ( size(_) == i )
+}


### PR DESCRIPTION
- Choose expressions becomes uninterpreted functions under the same
  constraints.
- Fix bug with variablesOf considering choose binders as free.
- Silence evaluator errors when occuring with tentative lucky models.
  Note that choose expressions cannot be evaluated nor compiled.
