### PR TITLE
Introduces a phase to protect exact type of params

### DIFF
--- a/src/main/scala/leon/Main.scala
+++ b/src/main/scala/leon/Main.scala
@@ -5,6 +5,7 @@ object Main {
   lazy val allPhases: List[LeonPhase[_, _]] = {
     List(
       plugin.ExtractionPhase,
+      SubtypingPhase,
       xlang.ArrayTransformation,
       xlang.EpsilonElimination,
       xlang.ImperativeCodeElimination,
@@ -121,9 +122,9 @@ object Main {
   def computePipeline(settings: Settings): Pipeline[List[String], Any] = {
     import purescala.Definitions.Program
 
-    val pipeBegin : Pipeline[List[String],Program] = plugin.ExtractionPhase
+    val pipeBegin : Pipeline[List[String],Program] = plugin.ExtractionPhase andThen SubtypingPhase
 
-    val pipeSynthesis: Pipeline[Program, Program]=
+    val pipeSynthesis: Pipeline[Program, Program] =
       if (settings.synthesis) {
         synthesis.SynthesisPhase
       } else {

--- a/src/main/scala/leon/SubtypingPhase.scala
+++ b/src/main/scala/leon/SubtypingPhase.scala
@@ -1,0 +1,47 @@
+package leon
+
+import purescala.TypeTrees._
+import purescala.Trees._
+import purescala.Definitions._
+
+object SubtypingPhase extends LeonPhase[Program, Program] {
+
+  val name = "Subtyping"
+  val description = "Protection of function arguments with subtypes"
+
+  //note that this will mutate the existing program functions and
+  //not return a new different program
+  def run(ctx: LeonContext)(pgm: Program): Program = {
+    pgm.definedFunctions.foreach(fd => {
+
+      fd.precondition = {
+        val argTypesPreconditions = fd.args.flatMap(arg => arg.tpe match {
+          case cct@CaseClassType(cd) => Seq(CaseClassInstanceOf(cd, arg.id.toVariable))
+          case _ => Seq()
+        })
+        argTypesPreconditions match {
+          case Nil => fd.precondition
+          case xs => fd.precondition match {
+            case Some(p) => Some(And(p +: xs))
+            case None => Some(And(xs))
+          }
+        }
+      }
+
+      fd.postcondition = fd.returnType match {
+        case cct@CaseClassType(cd) => {
+          val subtypingConstraint = CaseClassInstanceOf(cd, ResultVariable())
+          fd.postcondition match {
+            case Some(p) => Some(And(subtypingConstraint, p))
+            case None => Some(subtypingConstraint)
+          }
+        }
+        case _ => fd.postcondition
+      }
+
+    })
+    pgm
+  }
+
+}
+

--- a/src/test/resources/regression/verification/purescala/valid/Subtyping1.scala
+++ b/src/test/resources/regression/verification/purescala/valid/Subtyping1.scala
@@ -1,0 +1,31 @@
+object Subtyping1 {
+
+  sealed abstract class Tree
+  case class Leaf() extends Tree
+  case class Node(left: Tree, value: Int, right: Tree) extends Tree
+
+  def content(t: Tree) : Set[Int] = t match {
+    case Leaf() => Set.empty
+    case Node(l, v, r) => content(l) ++ Set(v) ++ content(r)
+  }
+
+  def treeMax(tree: Node): Int = {
+    tree match {
+      case Node(_, v, right) => right match {
+        case Leaf() => v
+        case Node(l, v, r) => treeMax(Node(l, v, r))
+      }
+    }
+  } ensuring(content(tree).contains(_))
+
+  def f2(tree: Node): Int = {
+    require(treeMax(tree) > 0)
+    tree match {
+      case Node(_, v, right) => right match {
+        case Leaf() => v
+        case Node(l, v, r) => treeMax(Node(l, v, r))
+      }
+    }
+  } ensuring(content(tree).contains(_))
+
+}

--- a/src/test/resources/regression/verification/purescala/valid/Subtyping2.scala
+++ b/src/test/resources/regression/verification/purescala/valid/Subtyping2.scala
@@ -1,0 +1,21 @@
+import leon.Utils._
+
+object Test {
+
+  abstract class List
+  case class Nil() extends List
+  case class Cons(head: Int, tail: List) extends List
+
+  def test(x: List): Nil = {
+    x match {
+      case Cons(_, tail) => test(tail)
+      case Nil() => Nil()
+    }
+  } ensuring((res: Nil) => isEmpty(res))
+
+  def isEmpty(x: List): Boolean = x match {
+    case Nil() => true
+    case _ => false
+  }
+
+}

--- a/src/test/scala/leon/test/verification/PureScalaVerificationRegression.scala
+++ b/src/test/scala/leon/test/verification/PureScalaVerificationRegression.scala
@@ -19,7 +19,7 @@ class PureScalaVerificationRegression extends FunSuite {
   private case class Output(report : VerificationReport, reporter : Reporter)
 
   private def mkPipeline : Pipeline[List[String],VerificationReport] =
-    leon.plugin.ExtractionPhase andThen leon.verification.AnalysisPhase
+    leon.plugin.ExtractionPhase andThen leon.SubtypingPhase andThen leon.verification.AnalysisPhase
 
   private def mkTest(file : File, leonOptions : Seq[LeonOption], forError: Boolean)(block: Output=>Unit) = {
     val fullName = file.getPath()

--- a/src/test/scala/leon/test/verification/XLangVerificationRegression.scala
+++ b/src/test/scala/leon/test/verification/XLangVerificationRegression.scala
@@ -19,7 +19,7 @@ class XLangVerificationRegression extends FunSuite {
   private case class Output(report : VerificationReport, reporter : Reporter)
 
   private def mkPipeline : Pipeline[List[String],VerificationReport] =
-    leon.plugin.ExtractionPhase andThen xlang.XlangAnalysisPhase
+    leon.plugin.ExtractionPhase andThen leon.SubtypingPhase andThen xlang.XlangAnalysisPhase
 
   private def mkTest(file : File, forError: Boolean = false)(block: Output=>Unit) = {
     val fullName = file.getPath()


### PR DESCRIPTION
This new phase is invoked after the extraction phase. It will
rewrite precondition of functions to add instanceOf when the
parameter is a case class concrete type (instead of abstract class).

If not done, then during the mapping to Z3 we lose the precise subtype
information, and Z3 will be able to find non valid counter-examples,
of a different case class for example.
