### PR TITLE
Fix choose with imperative phase

### DIFF
--- a/src/main/scala/leon/xlang/ImperativeCodeElimination.scala
+++ b/src/main/scala/leon/xlang/ImperativeCodeElimination.scala
@@ -244,6 +244,11 @@ object ImperativeCodeElimination extends LeonPhase[Program, (Program, Set[FunDef
         val (bodyRes, bodyScope, bodyFun) = toFunction(b)
         (bodyRes, (b2: Expr) => LetDef(newFd, bodyScope(b2)), bodyFun)
       }
+      case Choose(ids, b) => {
+        //Recall that Choose cannot mutate variables from the scope
+        val (bodyRes, bodyScope, bodyFun) = toFunction(b)
+        (bodyRes, (b2: Expr) => Choose(ids, bodyScope(b2)), bodyFun)
+      }
       case n @ NAryOperator(Seq(), recons) => (n, (body: Expr) => body, Map())
       case n @ NAryOperator(args, recons) => {
         val (recArgs, scope, fun) = args.foldRight((Seq[Expr](), (body: Expr) => body, Map[Identifier, Identifier]()))((arg, acc) => {

--- a/src/test/resources/regression/verification/xlang/valid/Choose1.scala
+++ b/src/test/resources/regression/verification/xlang/valid/Choose1.scala
@@ -1,0 +1,14 @@
+import leon.Utils._
+
+object Test {
+
+  def test(x: Int): Int = {
+
+    choose((y: Int) => {
+      val z = y + 2
+      z == y
+    })
+
+  } ensuring(_ == x + 2)
+
+}


### PR DESCRIPTION
Choose was introduced after imperative transformation
and was not adapted to the transformation rule.

Since Choose can introduce a scope, val defined
inside its body should not be hoisted outside.
