### PR TITLE
Clean TreeOps API

### DIFF
--- a/src/main/scala/leon/frontends/scalac/CodeExtraction.scala
+++ b/src/main/scala/leon/frontends/scalac/CodeExtraction.scala
@@ -379,7 +379,7 @@ trait CodeExtraction extends ASTExtractors {
       } else {
         val recGuard = extractTree(cd.guard)
 
-        if(!isPure(recGuard)) {
+        if(isXLang(recGuard)) {
           reporter.error(cd.guard.pos, "Guard expression must be pure")
           throw ImpureCodeEncounteredException(cd)
         }
@@ -1056,15 +1056,9 @@ trait CodeExtraction extends ASTExtractors {
   }
 
   def containsLetDef(expr: LeonExpr): Boolean = {
-    def convert(t : LeonExpr) : Boolean = t match {
-      case (l : LetDef) => true
+    exists { _ match {
+      case (l: LetDef) => true
       case _ => false
-    }
-    def combine(c1 : Boolean, c2 : Boolean) : Boolean = c1 || c2
-    def compute(t : LeonExpr, c : Boolean) = t match {
-      case (l : LetDef) => true
-      case _ => c
-    }
-    treeCatamorphism(convert, combine, compute, expr)
+    }}(expr)
   }
 }

--- a/src/main/scala/leon/synthesis/condabd/SynthesizerExamples.scala
+++ b/src/main/scala/leon/synthesis/condabd/SynthesizerExamples.scala
@@ -414,7 +414,7 @@ class SynthesizerForRuleExamples(
 	    
 	    //import TreeOps._
       //matchToIfThenElse(searchAndReplace(replaceChoose)(holeFunDefBody))
-	    TreeOps.searchAndReplace(replaceChoose)(TreeOps.matchToIfThenElse(holeFunDefBody))
+	    TreeOps.postMap(replaceChoose)(TreeOps.matchToIfThenElse(holeFunDefBody))
     }
     //accumulatingExpressionMatch = accumulatingExpression
 
@@ -626,7 +626,7 @@ class SynthesizerForRuleExamples(
 				    import TreeOps._
 //				    println("ifInInnermostElse " + ifInInnermostElse)
 //				    println("acc expr before replace: " + accumulatingExpression(ifInInnermostElse))
-				    val newBody = searchAndReplace(replaceFunDef)(accumulatingExpression(ifInInnermostElse))
+				    val newBody = postMap(replaceFunDef)(accumulatingExpression(ifInInnermostElse))
 				    
 				    newFun.body = Some(newBody)
 				    
@@ -698,7 +698,7 @@ class SynthesizerForRuleExamples(
 				      IfExpr(innerSnippetTree, snippetTree, error)
 				    
 				    import TreeOps._
-				    val newBody = searchAndReplace(replaceFunDef)(accumulatingExpression(ifInInnermostElse))
+				    val newBody = postMap(replaceFunDef)(accumulatingExpression(ifInInnermostElse))
 				    
 				    newFun.body = Some(newBody)
 				    

--- a/src/main/scala/leon/synthesis/condabd/examples/InputExamples.scala
+++ b/src/main/scala/leon/synthesis/condabd/examples/InputExamples.scala
@@ -44,7 +44,7 @@ object InputExamples {
       
     models.toList.map(m => (ins zip m).toMap).map( innerMap =>
       innerMap.map( innerEl => innerEl match {
-        case (id, expr) => (id, searchAndReplace(foundInteger)(expr))
+        case (id, expr) => (id, postMap(foundInteger)(expr))
       })
     )
   }

--- a/src/main/scala/leon/synthesis/condabd/ranking/Candidate.scala
+++ b/src/main/scala/leon/synthesis/condabd/ranking/Candidate.scala
@@ -91,7 +91,7 @@ case class CodeGenCandidate(expr: Expr, bodyExpr: Expr, weight: Weight, holeFunD
         Some(FunctionInvocation(newFun, args))
       case _ => None
     }
-    val newBody = searchAndReplace(replaceFunDef)(bodyExpr)
+    val newBody = postMap(replaceFunDef)(bodyExpr)
     
     newFun.body = Some(newBody)
     

--- a/src/main/scala/leon/synthesis/condabd/verification/AbstractVerifier.scala
+++ b/src/main/scala/leon/synthesis/condabd/verification/AbstractVerifier.scala
@@ -81,7 +81,7 @@ abstract class AbstractVerifier(solverf: SolverFactory[Solver with IncrementalSo
       case _ => None
     }
     
-    val newBody = searchAndReplace(replaceRecursiveCalls)(body)
+    val newBody = postMap(replaceRecursiveCalls)(body)
        
     // build the verification condition
     val resFresh = FreshIdentifier("result", true).setType(newBody.getType)

--- a/src/main/scala/leon/synthesis/utils/SynthesisProblemExtractionPhase.scala
+++ b/src/main/scala/leon/synthesis/utils/SynthesisProblemExtractionPhase.scala
@@ -19,20 +19,17 @@ object SynthesisProblemExtractionPhase extends LeonPhase[Program, (Program, Map[
     def noop(u:Expr, u2: Expr) = u
 
 
-    def actOnChoose(f: FunDef)(e: Expr, a: Expr): Expr = e match {
+    def actOnChoose(f: FunDef)(e: Expr) = e match {
       case ch @ Choose(vars, pred) =>
         val problem = Problem.fromChoose(ch)
 
         results += f -> (results.getOrElse(f, Seq()) :+ problem)
-
-        a
       case _ =>
-        a
     }
 
     // Look for choose()
     for (f <- p.definedFunctions.sortBy(_.id.toString) if f.body.isDefined) {
-      treeCatamorphism(x => x, noop, actOnChoose(f), f.body.get)
+      preTraversal(actOnChoose(f))(f.body.get)
     }
 
     (p, results)

--- a/src/main/scala/leon/termination/Processor.scala
+++ b/src/main/scala/leon/termination/Processor.scala
@@ -115,7 +115,9 @@ trait Solvable { self: Processor =>
         fi -> FreshIdentifier("noRun", true).setType(fi.getType).toVariable
     }).toMap
 
-    val expr = searchAndReplace(dangerousCallsMap.get, recursive=false)(problem)
+    // TODO: Fix&check without the recursive=false
+    //val expr = searchAndReplace(dangerousCallsMap.get, recursive=false)(problem)
+    val expr = postMap(dangerousCallsMap.lift)(problem)
 
     object Solved {
       def unapply(se: SolverFactory[Solver]): Option[Solution] = {

--- a/src/main/scala/leon/xlang/EpsilonElimination.scala
+++ b/src/main/scala/leon/xlang/EpsilonElimination.scala
@@ -20,8 +20,8 @@ object EpsilonElimination extends TransformationPhase {
 
     val allFuns = pgm.definedFunctions
     allFuns.foreach(fd => fd.body.map(body => {
-      val newBody = searchAndReplaceDFS{
-        case eps@Epsilon(pred) => {
+      val newBody = postMap{
+        case eps@Epsilon(pred) =>
           val freshName = FreshIdentifier("epsilon")
           val newFunDef = new FunDef(freshName, eps.getType, Seq())
           val epsilonVar = EpsilonVariable(eps.getPos)
@@ -29,8 +29,9 @@ object EpsilonElimination extends TransformationPhase {
           val postcondition = replace(Map(epsilonVar -> Variable(resId)), pred)
           newFunDef.postcondition = Some((resId, postcondition))
           Some(LetDef(newFunDef, FunctionInvocation(newFunDef, Seq())))
-        }
-        case _ => None
+
+        case _ =>
+          None
       }(body)
       fd.body = Some(newBody)
     }))

--- a/src/test/scala/leon/test/condabd/EvaluationTest.scala
+++ b/src/test/scala/leon/test/condabd/EvaluationTest.scala
@@ -152,11 +152,11 @@ class EvaluationTest extends FunSuite {
       }
 
       val body1 =
-        searchAndReplace(replaceFun)(
+        postMap(replaceFun)(
           program.definedFunctions.find(_.id.name == "testFun1").get.body.get)
 
       val body2 =
-        searchAndReplace(replaceFun)(
+        postMap(replaceFun)(
           program.definedFunctions.find(_.id.name == "testFun2").get.body.get)
 
       val evaluationStrategy = new CodeGenEvaluationStrategy(program, funDef, sctx.context, 500)
@@ -206,10 +206,10 @@ class EvaluationTest extends FunSuite {
       }
 
       val body1 =
-        searchAndReplace(replaceFun)(
+        postMap(replaceFun)(
           program.definedFunctions.find(_.id.name == "testFun1").get.body.get)
       val body2 =
-        searchAndReplace(replaceFun)(
+        postMap(replaceFun)(
           program.definedFunctions.find(_.id.name == "testFun2").get.body.get)
 
       // evaluate expressions with let
@@ -228,7 +228,7 @@ class EvaluationTest extends FunSuite {
               Some(FunctionInvocation(newFun, args))
             case _ => None
           }
-          val newBody = searchAndReplace(replaceFunDef)(expr)
+          val newBody = postMap(replaceFunDef)(expr)
 
           newFun.body = Some(newBody)
 
@@ -287,7 +287,7 @@ class EvaluationTest extends FunSuite {
               Some(FunctionInvocation(newFun, args))
             case _ => None
           }
-          val newBody = searchAndReplace(replaceFunDef)(expr)
+          val newBody = postMap(replaceFunDef)(expr)
 
           newFun.body = Some(newBody)
 


### PR DESCRIPTION
- remove superfluous implementations doing almost the same
- introduce pre/post traversal and transformers as foreach/map/fold
- Redefine other operations exists, contains, as folds
