### PR TITLE
EnumeratingSolver / PortfolioSolver

### DIFF
--- a/src/main/scala/leon/datagen/DataGenerator.scala
+++ b/src/main/scala/leon/datagen/DataGenerator.scala
@@ -5,7 +5,20 @@ package datagen
 
 import purescala.Trees._
 import purescala.Common._
+import utils._
 
-trait DataGenerator {
+import java.util.concurrent.atomic.AtomicBoolean
+
+trait DataGenerator extends Interruptible {
   def generateFor(ins: Seq[Identifier], satisfying: Expr, maxValid: Int, maxEnumerated: Int): Iterator[Seq[Expr]];
+
+  protected val interrupted: AtomicBoolean = new AtomicBoolean(false)
+
+  def interrupt(): Unit = {
+    interrupted.set(true)
+  }
+
+  def recoverInterrupt(): Unit = {
+    interrupted.set(false)
+  }
 }

--- a/src/main/scala/leon/datagen/NaiveDataGen.scala
+++ b/src/main/scala/leon/datagen/NaiveDataGen.scala
@@ -118,6 +118,7 @@ class NaiveDataGen(ctx: LeonContext, p: Program, evaluator: Evaluator, _bounds :
 
       naryProduct(ins.map(id => generate(id.getType, bounds)))
         .take(maxEnumerated)
+        .takeWhile(s => !interrupted.get)
         .filter{s => evalFun(s) == sat }
         .take(maxValid)
         .iterator

--- a/src/main/scala/leon/solvers/EnumerationSolver.scala
+++ b/src/main/scala/leon/solvers/EnumerationSolver.scala
@@ -1,0 +1,73 @@
+/* Copyright 2009-2013 EPFL, Lausanne */
+
+package leon
+package solvers
+
+import utils._
+import purescala.Common._
+import purescala.Definitions._
+import purescala.Trees._
+import purescala.Extractors._
+import purescala.TreeOps._
+import purescala.TypeTrees._
+
+import datagen._
+
+
+class EnumerationSolver(val context: LeonContext, val program: Program) extends Solver with Interruptible {
+  def name = "Enum"
+
+  val maxTried = 10000;
+
+  var datagen: DataGenerator = _
+
+  var freeVars    = List[Identifier]()
+  var constraints = List[Expr]()
+
+  def assertCnstr(expression: Expr): Unit = {
+    constraints ::= expression
+
+    val newFreeVars = (variablesOf(expression) -- freeVars).toList
+    freeVars = freeVars ::: newFreeVars
+  }
+
+  private var modelMap = Map[Identifier, Expr]()
+
+  def check: Option[Boolean] = {
+    try { 
+      val muteContext = context.copy(reporter = new DefaultReporter(context.settings))
+      datagen = new VanuatooDataGen(muteContext, program)
+
+      modelMap = Map()
+
+      val it = datagen.generateFor(freeVars, And(constraints.reverse), 1, maxTried)
+
+      if (it.hasNext) {
+        val model = it.next
+        modelMap = (freeVars zip model).toMap
+        Some(true)
+      } else {
+        None
+      }
+    } catch {
+      case e: codegen.CompilationException =>
+        None
+    }
+  }
+
+  def getModel: Map[Identifier, Expr] = {
+    modelMap
+  }
+
+  def free() = {
+    constraints = Nil
+  }
+
+  def interrupt(): Unit = {
+    Option(datagen).foreach(_.interrupt)
+  }
+
+  def recoverInterrupt(): Unit = {
+    Option(datagen).foreach(_.recoverInterrupt)
+  }
+}

--- a/src/main/scala/leon/solvers/combinators/PortfolioSolver.scala
+++ b/src/main/scala/leon/solvers/combinators/PortfolioSolver.scala
@@ -1,0 +1,84 @@
+/* Copyright 2009-2013 EPFL, Lausanne */
+
+package leon
+package solvers
+package combinators
+
+import purescala.Common._
+import purescala.Definitions._
+import purescala.Trees._
+import purescala.TreeOps._
+import purescala.TypeTrees._
+
+import utils.Interruptible
+import scala.concurrent._
+import scala.concurrent.duration._
+
+import scala.collection.mutable.{Map=>MutableMap}
+
+import ExecutionContext.Implicits.global
+
+class PortfolioSolver(val context: LeonContext, solvers: Seq[SolverFactory[Solver with Interruptible]])
+        extends Solver with Interruptible {
+
+  val name = "Pfolio"
+
+  var constraints = List[Expr]()
+
+  def assertCnstr(expression: Expr): Unit = {
+    constraints ::= expression
+  }
+
+  private var modelMap = Map[Identifier, Expr]()
+  private var solversInsts = Seq[Solver with Interruptible]()
+
+  def check: Option[Boolean] = {
+    modelMap = Map()
+
+    // create fresh solvers
+    solversInsts = solvers.map(_.getNewSolver)
+
+    // assert
+    solversInsts.foreach { s =>
+      s.assertCnstr(And(constraints.reverse))
+    }
+
+    // solving
+    val fs = solversInsts.map { s =>
+      Future {
+        (s, s.check, s.getModel)
+      }
+    }
+
+    val result = Future.find(fs)(_._2.isDefined)
+
+    val res = Await.result(result, 10.days) match {
+      case Some((s, r, m)) =>
+        modelMap = m
+        solversInsts.foreach(_.interrupt)
+        r
+      case None =>
+        None
+    }
+
+    solversInsts.foreach(_.free)
+
+    res
+  }
+
+  def getModel: Map[Identifier, Expr] = {
+    modelMap
+  }
+
+  def free() = {
+    constraints = Nil
+  }
+
+  def interrupt(): Unit = {
+    solversInsts.foreach(_.interrupt())
+  }
+
+  def recoverInterrupt(): Unit = {
+    solversInsts.foreach(_.recoverInterrupt())
+  }
+}

--- a/src/main/scala/leon/synthesis/Synthesizer.scala
+++ b/src/main/scala/leon/synthesis/Synthesizer.scala
@@ -83,7 +83,7 @@ class Synthesizer(val context : LeonContext,
 
     val solverf = SolverFactory(() => (new FairZ3Solver(context, npr) with TimeoutSolver).setTimeout(timeoutMs))
 
-    val vctx = VerificationContext(context, npr, Seq(solverf), context.reporter)
+    val vctx = VerificationContext(context, npr, solverf, context.reporter)
     val vcs = generateVerificationConditions(vctx, fds.map(_.id.name))
     val vcreport = checkVerificationConditions(vctx, vcs)
 

--- a/src/main/scala/leon/verification/VerificationContext.scala
+++ b/src/main/scala/leon/verification/VerificationContext.scala
@@ -11,6 +11,6 @@ import java.util.concurrent.atomic.AtomicBoolean
 case class VerificationContext (
   context: LeonContext,
   program: Program,
-  solvers: Seq[SolverFactory[Solver]],
+  solverFactory: SolverFactory[Solver],
   reporter: Reporter
 )

--- a/src/test/scala/leon/test/solvers/EnumerationSolverTests.scala
+++ b/src/test/scala/leon/test/solvers/EnumerationSolverTests.scala
@@ -1,0 +1,44 @@
+/* Copyright 2009-2013 EPFL, Lausanne */
+
+package leon.test
+package solvers
+
+import leon._
+import leon.utils.Interruptible
+import leon.solvers._
+import leon.solvers.combinators._
+import leon.purescala.Common._
+import leon.purescala.Definitions._
+import leon.purescala.Trees._
+import leon.purescala.TypeTrees._
+
+class EnumerationSolverTests extends LeonTestSuite {
+  private def check(sf: SolverFactory[Solver], e: Expr): Option[Boolean] = {
+    val s = sf.getNewSolver
+    s.assertCnstr(e)
+    s.check
+  }
+
+  private def getSolver = {
+    SolverFactory(() => new EnumerationSolver(testContext, Program.empty))
+  }
+
+  test("EnumerationSolver 1 (true)") {
+    val sf = getSolver
+    assert(check(sf, BooleanLiteral(true)) === Some(true))
+  }
+
+  test("EnumerationSolver 2 (x == 1)") {
+    val sf = getSolver
+    val x = Variable(FreshIdentifier("x").setType(Int32Type))
+    val o = IntLiteral(1)
+    assert(check(sf, Equals(x, o)) === Some(true))
+  }
+
+  test("EnumerationSolver 3 (Limited range for ints)") {
+    val sf = getSolver
+    val x = Variable(FreshIdentifier("x").setType(Int32Type))
+    val o = IntLiteral(42)
+    assert(check(sf, Equals(x, o)) === None)
+  }
+}


### PR DESCRIPTION
Use a datagen-based solver to find simple counter-examples. Note that
this solver returns Unknown most of the time, so it is best to combine
it with a full-fledged solver.

PortfolioSolver allows us to combine solvers and have them run in
parallel. The first result (!= Unknown) is used. Solvers can be selected
for verification using the --solvers option.
