### PR TITLE
Updated unrolling solver to work with UninterpretedZ3Solver

### DIFF
--- a/src/main/scala/leon/solvers/combinators/PortfolioSolver.scala
+++ b/src/main/scala/leon/solvers/combinators/PortfolioSolver.scala
@@ -18,7 +18,7 @@ import scala.collection.mutable.{Map=>MutableMap}
 
 import ExecutionContext.Implicits.global
 
-class PortfolioSolver(val context: LeonContext, solvers: Seq[SolverFactory[AssumptionSolver with IncrementalSolver with Interruptible]])
+class PortfolioSolver(val context: LeonContext, solvers: Seq[SolverFactory[Solver with IncrementalSolver with Interruptible]])
         extends Solver with IncrementalSolver with Interruptible with NaiveAssumptionSolver {
 
   val name = "Pfolio"

--- a/src/main/scala/leon/verification/AnalysisPhase.scala
+++ b/src/main/scala/leon/verification/AnalysisPhase.scala
@@ -23,7 +23,7 @@ object AnalysisPhase extends LeonPhase[Program,VerificationReport] {
 
   override val definedOptions : Set[LeonOptionDef] = Set(
     LeonValueOptionDef("functions", "--functions=f1:f2", "Limit verification to f1,f2,..."),
-    LeonValueOptionDef("solvers",   "--solvers=s1,s2",   "Use solvers s1 and s2 (fairz3,enum)", default = Some("fairz3")),
+    LeonValueOptionDef("solvers",   "--solvers=s1,s2",   "Use solvers s1 and s2 (fairz3,enum,unroll)", default = Some("fairz3")),
     LeonValueOptionDef("timeout",   "--timeout=T",       "Timeout after T seconds when trying to prove a verification condition.")
   )
 
@@ -151,7 +151,11 @@ object AnalysisPhase extends LeonPhase[Program,VerificationReport] {
 
     val allSolvers = Map(
       "fairz3" -> SolverFactory(() => new FairZ3Solver(ctx, program) with TimeoutSolver),
-      "enum"   -> SolverFactory(() => new EnumerationSolver(ctx, program) with TimeoutSolver)
+      "enum"   -> SolverFactory(() => new EnumerationSolver(ctx, program) with TimeoutSolver),
+      "unroll" -> {
+        val uninterpretedZ3 = SolverFactory(() => new UninterpretedZ3Solver(ctx, program))
+        SolverFactory(() => new UnrollingSolver(ctx, uninterpretedZ3) with TimeoutSolver)
+      }
     )
 
     val reporter = ctx.reporter


### PR DESCRIPTION
UnrollingSolver with UninterpretedZ3Solver not as powerful as FairZ3Solver. Running

./leon src/test/resources/regression/verification/purescala/valid/AmortizedQueue.java

will not terminate whereas it takes only a few milliseconds using the FairZ3Solver. I don't really see how unrolling more could keep the UnrollingSolver from getting the right proof...
