### PR TITLE
Refactor FiniteArray to an implicit representation

### DIFF
--- a/src/main/scala/leon/codegen/CodeGeneration.scala
+++ b/src/main/scala/leon/codegen/CodeGeneration.scala
@@ -650,8 +650,9 @@ trait CodeGeneration {
         ch << storeInstr
         //returns targetArray
 
-      case a @ FiniteArray(es) =>
-        ch << Ldc(es.size)
+      case a @ FiniteArray(elems, default, length) =>
+        val IntLiteral(l) = length
+        ch << Ldc(l)
         val storeInstr = a.getType match {
           case ArrayType(CharType) => ch << NewArray.primitive("T_CHAR"); CASTORE
           case ArrayType(Int32Type) => ch << NewArray.primitive("T_INT"); IASTORE
@@ -659,7 +660,7 @@ trait CodeGeneration {
           case ArrayType(other) => ch << NewArray(typeToJVM(other)); AASTORE
           case other => throw CompilationException("Cannot compile finite array expression whose type is %s.".format(other))
         }
-        for((e,i) <- es.zipWithIndex) {
+        for((i, e) <- elems) {
           ch << DUP << Ldc(i)
           mkExpr(e, ch) 
           ch << storeInstr

--- a/src/main/scala/leon/codegen/CompilationUnit.scala
+++ b/src/main/scala/leon/codegen/CompilationUnit.scala
@@ -146,8 +146,8 @@ class CompilationUnit(val ctx: LeonContext,
 
     // For now, we only treat boolean arrays separately.
     // We have a use for these, mind you.
-    case f @ FiniteArray(exprs) if f.getType == ArrayType(BooleanType) =>
-      exprs.map(e => exprToJVM(e).asInstanceOf[java.lang.Boolean].booleanValue).toArray
+    //case f @ FiniteArray(exprs) if f.getType == ArrayType(BooleanType) =>
+    //  exprs.map(e => exprToJVM(e).asInstanceOf[java.lang.Boolean].booleanValue).toArray
 
     case s @ FiniteSet(els) =>
       val s = new leon.codegen.runtime.Set()

--- a/src/main/scala/leon/frontends/scalac/CodeExtraction.scala
+++ b/src/main/scala/leon/frontends/scalac/CodeExtraction.scala
@@ -1365,7 +1365,7 @@ trait CodeExtraction extends ASTExtractors {
           val underlying = extractType(baseType)
           val lengthRec = extractTree(length)
           val defaultValueRec = extractTree(defaultValue)
-          ArrayFill(lengthRec, defaultValueRec)
+          FiniteArray(Map(), Some(defaultValueRec), lengthRec).setType(ArrayType(underlying))
 
         case ExIfThenElse(t1,t2,t3) =>
           val r1 = extractTree(t1)

--- a/src/main/scala/leon/purescala/TreeOps.scala
+++ b/src/main/scala/leon/purescala/TreeOps.scala
@@ -1016,7 +1016,7 @@ object TreeOps {
     case SetType(baseType)          => FiniteSet(Set()).setType(tpe)
     case MapType(fromType, toType)  => FiniteMap(Seq()).setType(tpe)
     case TupleType(tpes)            => Tuple(tpes.map(simplestValue))
-    case ArrayType(tpe)             => ArrayFill(IntLiteral(0), simplestValue(tpe))
+    case ArrayType(tpe)             => FiniteArray(Map(), Some(simplestValue(tpe)), IntLiteral(0)).setType(ArrayType(tpe))
 
     case act @ AbstractClassType(acd, tpe) =>
       val children = acd.knownChildren

--- a/src/main/scala/leon/purescala/Trees.scala
+++ b/src/main/scala/leon/purescala/Trees.scala
@@ -430,8 +430,8 @@ object Trees {
     val getType = BooleanType
   }
 
-  /* Array operations */
 
+  /* Array operations */
   case class ArraySelect(array: Expr, index: Expr) extends Expr {
     def getType = array.getType match {
       case ArrayType(base) =>
@@ -454,7 +454,15 @@ object Trees {
     val getType = Int32Type
   }
 
-  case class FiniteArray(exprs: Seq[Expr]) extends Expr with MutableTyped
+  case class FiniteArray(elems: Map[Int, Expr], default: Option[Expr], length: Expr) extends Expr with MutableTyped
+
+  object FiniteArray {
+    def apply(elems: Seq[Expr]): FiniteArray = {
+      val res = FiniteArray(elems.zipWithIndex.map(_.swap).toMap, None, IntLiteral(elems.size))
+      elems.headOption.foreach(e => res.setType(ArrayType(e.getType)))
+      res
+    }
+  }
 
   /* Special trees */
 

--- a/src/main/scala/leon/solvers/smtlib/SMTLIBCVC4Target.scala
+++ b/src/main/scala/leon/solvers/smtlib/SMTLIBCVC4Target.scala
@@ -98,13 +98,13 @@ trait SMTLIBCVC4Target extends SMTLIBTarget {
   }
 
   override def toSMT(e: Expr)(implicit bindings: Map[Identifier, Term]) = e match {
-    case a @ FiniteArray(elems) =>
+    case a @ FiniteArray(elems, default, size) =>
       val tpe @ ArrayType(base) = normalizeType(a.getType)
       declareSort(tpe)
 
       var ar: Term = declareVariable(FreshIdentifier("arrayconst").setType(RawArrayType(Int32Type, base)))
 
-      for ((e, i) <- elems.zipWithIndex) {
+      for ((i, e) <- elems) {
         ar = FunctionApplication(SSymbol("store"), Seq(ar, toSMT(IntLiteral(i)), toSMT(e)))
       }
 

--- a/src/main/scala/leon/solvers/smtlib/SMTLIBTarget.scala
+++ b/src/main/scala/leon/solvers/smtlib/SMTLIBTarget.scala
@@ -526,9 +526,17 @@ trait SMTLIBTarget {
           val IntLiteral(size)                 = fromSMT(args(0), Int32Type)
           val RawArrayValue(_, elems, default) = fromSMT(args(1), RawArrayType(Int32Type, at.base))
 
-          val entries = for (i <- 0 to size-1) yield elems.getOrElse(IntLiteral(i), default)
+          if(size > 10) {
+            val definedElements = elems.collect{
+              case (IntLiteral(i), value) => (i, value)
+            }.toMap
+            FiniteArray(definedElements, Some(default), IntLiteral(size)).setType(at)
 
-          FiniteArray(entries).setType(at)
+          } else {
+            val entries = for (i <- 0 to size-1) yield elems.getOrElse(IntLiteral(i), default)
+
+            FiniteArray(entries).setType(at)
+          }
 
         case t =>
           unsupported("Woot? structural type that is non-structural: "+t)

--- a/src/main/scala/leon/solvers/smtlib/SMTLIBZ3Target.scala
+++ b/src/main/scala/leon/solvers/smtlib/SMTLIBZ3Target.scala
@@ -85,14 +85,15 @@ trait SMTLIBZ3Target extends SMTLIBTarget {
   }
 
   override def toSMT(e: Expr)(implicit bindings: Map[Identifier, Term]): Term = e match {
-      case a @ FiniteArray(elems) =>
+      case a @ FiniteArray(elems, oDef, size) =>
         val tpe @ ArrayType(base) = normalizeType(a.getType)
         declareSort(tpe)
 
+        val default: Expr = oDef.getOrElse(simplestValue(base))
         
-        var ar: Term = ArrayConst(declareSort(RawArrayType(Int32Type, base)), toSMT(simplestValue(base)))
+        var ar: Term = ArrayConst(declareSort(RawArrayType(Int32Type, base)), toSMT(default))
 
-        for ((e, i) <- elems.zipWithIndex) {
+        for ((i, e) <- elems) {
           ar = ArraysEx.Store(ar, toSMT(IntLiteral(i)), toSMT(e))
         }
 

--- a/src/main/scala/leon/verification/VerificationReport.scala
+++ b/src/main/scala/leon/verification/VerificationReport.scala
@@ -4,7 +4,6 @@ package leon
 package verification
 
 import purescala.Definitions.FunDef
-import purescala.ScalaPrinter
 
 class VerificationReport(val fvcs: Map[FunDef, List[VerificationCondition]]) {
   import scala.math.Ordering.Implicits._

--- a/src/test/resources/regression/verification/purescala/invalid/BigArray.scala
+++ b/src/test/resources/regression/verification/purescala/invalid/BigArray.scala
@@ -1,0 +1,11 @@
+import leon.annotation._
+import leon.lang._
+
+object BigArray {
+
+  def big(a: Array[Int]): Int = {
+    require(a.length >= 10 && a(7) == 42)
+    a.length
+  } ensuring(_ <= 1000000000)
+
+}

--- a/src/test/scala/leon/test/evaluators/DefaultEvaluatorTests.scala
+++ b/src/test/scala/leon/test/evaluators/DefaultEvaluatorTests.scala
@@ -103,4 +103,47 @@ class DefaultEvaluatorTests extends leon.test.LeonTestSuite {
       defaultEvaluator.eval(Let(id, IntLiteral(42), Variable(id))),
       IntLiteral(42))
   }
+
+
+  test("eval literal array ops") {
+    expectSuccessful(
+      defaultEvaluator.eval(FiniteArray(Map(), Some(IntLiteral(12)), IntLiteral(7)).setType(ArrayType(Int32Type))),
+      FiniteArray(Map(), Some(IntLiteral(12)), IntLiteral(7)))
+    expectSuccessful(
+      defaultEvaluator.eval(
+        ArrayLength(FiniteArray(Map(), Some(IntLiteral(12)), IntLiteral(7)).setType(ArrayType(Int32Type)))),
+      IntLiteral(7))
+    expectSuccessful(
+      defaultEvaluator.eval(ArraySelect(
+        FiniteArray(Seq(IntLiteral(2), IntLiteral(4), IntLiteral(7))),
+        IntLiteral(1))),
+      IntLiteral(4))
+    expectSuccessful(
+      defaultEvaluator.eval(
+        ArrayUpdated(
+          FiniteArray(Seq(IntLiteral(2), IntLiteral(4), IntLiteral(7))),
+          IntLiteral(1),
+          IntLiteral(42))),
+      FiniteArray(Seq(IntLiteral(2), IntLiteral(42), IntLiteral(7))))
+  }
+
+  test("eval variable length of array") {
+    val id = FreshIdentifier("id").setType(Int32Type)
+    expectSuccessful(
+      defaultEvaluator.eval(
+        ArrayLength(
+          FiniteArray(Map(), Some(IntLiteral(12)), Variable(id))
+          .setType(ArrayType(Int32Type))),
+        Map(id -> IntLiteral(27))),
+      IntLiteral(27))
+  }
+
+  test("eval variable default value of array") {
+    val id = FreshIdentifier("id").setType(Int32Type)
+    expectSuccessful(
+      defaultEvaluator.eval(
+        FiniteArray(Map(), Some(Variable(id)), IntLiteral(7)).setType(ArrayType(Int32Type)),
+        Map(id -> IntLiteral(27))),
+      FiniteArray(Map(), Some(IntLiteral(27)), IntLiteral(7)))
+  }
 }


### PR DESCRIPTION
FiniteArray now takes an Expr for the length, a default
Expr, and a Map of defined Expr for some of its elements.
Adapt the rest of Leon to the new trees.

The PrettyPrinter tries to be a little bit smart about
how to print the array, only printing a few elements when the
array gets too big. The regression test produces an
huge array counter-example that used to lead to a crash of
Leon with the previous implementation of Array (fully represented
in memory).