### PR TITLE
Leon define its own Sets

### DIFF
--- a/library/collection/package.scala
+++ b/library/collection/package.scala
@@ -4,6 +4,7 @@ package leon
 
 import leon.annotation._
 import leon.collection.List
+import leon.lang._
 import leon.lang.synthesis.choose
 
 package object collection {

--- a/library/lang/Set.scala
+++ b/library/lang/Set.scala
@@ -1,0 +1,18 @@
+package leon.lang
+import leon.annotation._
+
+object Set {
+  def empty[T] = Set[T]()
+}
+
+@ignore
+case class Set[T](elems: T*) {
+  def +(a: T): Set[T] = ???
+  def ++(a: Set[T]): Set[T] = ???
+  def -(a: T): Set[T] = ???
+  def --(a: Set[T]): Set[T] = ???
+  def contains(a: T): Boolean = ???
+  def isEmpty: Boolean = ???
+  def subsetOf(b: Set[T]): Boolean = ???
+  def &(a: Set[T]): Set[T] = ???
+}

--- a/src/main/scala/leon/frontends/scalac/ExtractionPhase.scala
+++ b/src/main/scala/leon/frontends/scalac/ExtractionPhase.scala
@@ -36,10 +36,11 @@ object ExtractionPhase extends LeonPhase[List[String], Program] {
       "make sure to set the ECLIPSE_HOME environment variable to your Eclipse installation home directory"
     ))
     
-    settings.classpath.value = scalaLib
-    settings.usejavacp.value = false
-    settings.Yrangepos.value = true
-    settings.skip.value      = List("patmat")
+    settings.classpath.value   = scalaLib
+    settings.usejavacp.value   = false
+    settings.deprecation.value = true
+    settings.Yrangepos.value   = true
+    settings.skip.value        = List("patmat")
 
     val compilerOpts = Build.libFiles ::: args.filterNot(_.startsWith("--"))
 

--- a/src/main/scala/leon/frontends/scalac/SimpleReporter.scala
+++ b/src/main/scala/leon/frontends/scalac/SimpleReporter.scala
@@ -53,26 +53,12 @@ class SimpleReporter(val settings: Settings, reporter: leon.Reporter) extends Ab
       case _ =>
         val buf = new StringBuilder(msg)
         val lpos = LeonOffsetPosition(pos.line, pos.column, pos.point, pos.source.file.file)
-        printMessage(msg+"\n"+getSourceLine(pos), lpos, severity)
+        printMessage(msg, lpos, severity)
     }
   }
+
   def print(pos: Position, msg: String, severity: Severity) {
     printMessage(pos, clabel(severity) + msg, severity)
-  }
-
-  def getSourceLine(pos: Position) = {
-    pos.lineContent.stripLineEnd+getColumnMarker(pos)
-  }
-
-  def getColumnMarker(pos: Position) = if (pos.isDefined) { 
-      "\n"+(" " * (pos.column - 1) + "^")
-    } else {
-      ""
-    }
-  
-  def printSummary() {
-    if (WARNING.count > 0) printMessage(getCountString(WARNING) + " found", LeonNoPosition, INFO)
-    if (  ERROR.count > 0) printMessage(getCountString(ERROR  ) + " found", LeonNoPosition, INFO)
   }
 
   def display(pos: Position, msg: String, severity: Severity) {

--- a/src/test/resources/regression/repair/Heap4.scala
+++ b/src/test/resources/regression/repair/Heap4.scala
@@ -4,8 +4,9 @@
  * Date: 20.11.2013
  **/
 
+import leon._
+import leon.lang._
 import leon.collection._
-import leon._ 
 
 object HeapSort {
  

--- a/src/test/resources/regression/repair/MergeSort2.scala
+++ b/src/test/resources/regression/repair/MergeSort2.scala
@@ -1,5 +1,6 @@
 /* Copyright 2009-2015 EPFL, Lausanne */
 
+import leon.lang._
 import leon.collection._
 
 object MergeSort {

--- a/src/test/resources/regression/termination/valid/BinaryTreeImp.scala
+++ b/src/test/resources/regression/termination/valid/BinaryTreeImp.scala
@@ -1,6 +1,5 @@
 /* Copyright 2009-2015 EPFL, Lausanne */
 
-import scala.collection.immutable.Set
 import leon.annotation._
 import leon.lang._
 

--- a/src/test/resources/regression/termination/valid/ListWithSize.scala
+++ b/src/test/resources/regression/termination/valid/ListWithSize.scala
@@ -1,6 +1,5 @@
 /* Copyright 2009-2015 EPFL, Lausanne */
 
-import scala.collection.immutable.Set
 import leon.annotation._
 import leon.lang._
 

--- a/src/test/resources/regression/termination/valid/QuickSort.scala
+++ b/src/test/resources/regression/termination/valid/QuickSort.scala
@@ -1,6 +1,6 @@
 /* Copyright 2009-2015 EPFL, Lausanne */
 
-import scala.collection.immutable.Set
+import leon.lang._
 
 object QuickSort {
   sealed abstract class List

--- a/src/test/resources/regression/termination/valid/RedBlackTree.scala
+++ b/src/test/resources/regression/termination/valid/RedBlackTree.scala
@@ -1,7 +1,6 @@
 /* Copyright 2009-2015 EPFL, Lausanne */
 
-import scala.collection.immutable.Set
-//import scala.collection.immutable.Multiset
+import leon.lang._
 
 object RedBlackTree { 
   sealed abstract class Color

--- a/src/test/resources/regression/termination/valid/SimpInterpret.scala
+++ b/src/test/resources/regression/termination/valid/SimpInterpret.scala
@@ -1,6 +1,5 @@
 /* Copyright 2009-2015 EPFL, Lausanne */
 
-//import scala.collection.immutable.Set
 //import leon.annotation._
 import leon.lang._
 

--- a/src/test/resources/regression/verification/newsolvers/valid/AmortizedQueue.scala
+++ b/src/test/resources/regression/verification/newsolvers/valid/AmortizedQueue.scala
@@ -1,6 +1,5 @@
 /* Copyright 2009-2014 EPFL, Lausanne */
 
-import scala.collection.immutable.Set
 import leon.lang._
 import leon.annotation._
 

--- a/src/test/resources/regression/verification/newsolvers/valid/AssociativeList.scala
+++ b/src/test/resources/regression/verification/newsolvers/valid/AssociativeList.scala
@@ -1,6 +1,5 @@
 /* Copyright 2009-2014 EPFL, Lausanne */
 
-import scala.collection.immutable.Set
 import leon.lang._
 import leon.annotation._
 

--- a/src/test/resources/regression/verification/newsolvers/valid/InsertionSort.scala
+++ b/src/test/resources/regression/verification/newsolvers/valid/InsertionSort.scala
@@ -1,6 +1,5 @@
 /* Copyright 2009-2014 EPFL, Lausanne */
 
-import scala.collection.immutable.Set
 import leon.annotation._
 import leon.lang._
 

--- a/src/test/resources/regression/verification/newsolvers/valid/ListOperations.scala
+++ b/src/test/resources/regression/verification/newsolvers/valid/ListOperations.scala
@@ -1,6 +1,5 @@
 /* Copyright 2009-2014 EPFL, Lausanne */
 
-import scala.collection.immutable.Set
 import leon.annotation._
 import leon.lang._
 

--- a/src/test/resources/regression/verification/newsolvers/valid/PropositionalLogic.scala
+++ b/src/test/resources/regression/verification/newsolvers/valid/PropositionalLogic.scala
@@ -1,6 +1,5 @@
 /* Copyright 2009-2014 EPFL, Lausanne */
 
-import scala.collection.immutable.Set
 import leon.lang._
 import leon.annotation._
 

--- a/src/test/resources/regression/verification/newsolvers/valid/RedBlackTree.scala
+++ b/src/test/resources/regression/verification/newsolvers/valid/RedBlackTree.scala
@@ -1,6 +1,5 @@
 /* Copyright 2009-2014 EPFL, Lausanne */
 
-import scala.collection.immutable.Set
 import leon.annotation._
 import leon.lang._
 

--- a/src/test/resources/regression/verification/newsolvers/valid/SearchLinkedList.scala
+++ b/src/test/resources/regression/verification/newsolvers/valid/SearchLinkedList.scala
@@ -1,6 +1,5 @@
 /* Copyright 2009-2014 EPFL, Lausanne */
 
-import scala.collection.immutable.Set
 import leon.lang._
 import leon.annotation._
 

--- a/src/test/resources/regression/verification/purescala/invalid/InsertionSort.scala
+++ b/src/test/resources/regression/verification/purescala/invalid/InsertionSort.scala
@@ -1,6 +1,5 @@
 /* Copyright 2009-2015 EPFL, Lausanne */
 
-import scala.collection.immutable.Set
 import leon.annotation._
 import leon.lang._
 

--- a/src/test/resources/regression/verification/purescala/invalid/ListOperations.scala
+++ b/src/test/resources/regression/verification/purescala/invalid/ListOperations.scala
@@ -1,6 +1,5 @@
 /* Copyright 2009-2015 EPFL, Lausanne */
 
-import scala.collection.immutable.Set
 import leon.annotation._
 import leon.lang._
 

--- a/src/test/resources/regression/verification/purescala/invalid/PropositionalLogic.scala
+++ b/src/test/resources/regression/verification/purescala/invalid/PropositionalLogic.scala
@@ -1,6 +1,5 @@
 /* Copyright 2009-2015 EPFL, Lausanne */
 
-import scala.collection.immutable.Set
 import leon.lang._
 import leon.annotation._
 

--- a/src/test/resources/regression/verification/purescala/invalid/RedBlackTree.scala
+++ b/src/test/resources/regression/verification/purescala/invalid/RedBlackTree.scala
@@ -1,6 +1,5 @@
 /* Copyright 2009-2015 EPFL, Lausanne */
 
-import scala.collection.immutable.Set
 import leon.annotation._
 import leon.lang._
 

--- a/src/test/resources/regression/verification/purescala/valid/AmortizedQueue.scala
+++ b/src/test/resources/regression/verification/purescala/valid/AmortizedQueue.scala
@@ -1,6 +1,5 @@
 /* Copyright 2009-2015 EPFL, Lausanne */
 
-import scala.collection.immutable.Set
 import leon.lang._
 import leon.annotation._
 

--- a/src/test/resources/regression/verification/purescala/valid/AssociativeList.scala
+++ b/src/test/resources/regression/verification/purescala/valid/AssociativeList.scala
@@ -1,6 +1,5 @@
 /* Copyright 2009-2015 EPFL, Lausanne */
 
-import scala.collection.immutable.Set
 import leon.lang._
 import leon.annotation._
 

--- a/src/test/resources/regression/verification/purescala/valid/InsertionSort.scala
+++ b/src/test/resources/regression/verification/purescala/valid/InsertionSort.scala
@@ -1,6 +1,5 @@
 /* Copyright 2009-2015 EPFL, Lausanne */
 
-import scala.collection.immutable.Set
 import leon.annotation._
 import leon.lang._
 

--- a/src/test/resources/regression/verification/purescala/valid/ListOperations.scala
+++ b/src/test/resources/regression/verification/purescala/valid/ListOperations.scala
@@ -1,6 +1,5 @@
 /* Copyright 2009-2015 EPFL, Lausanne */
 
-import scala.collection.immutable.Set
 import leon.annotation._
 import leon.lang._
 

--- a/src/test/resources/regression/verification/purescala/valid/PropositionalLogic.scala
+++ b/src/test/resources/regression/verification/purescala/valid/PropositionalLogic.scala
@@ -1,6 +1,5 @@
 /* Copyright 2009-2015 EPFL, Lausanne */
 
-import scala.collection.immutable.Set
 import leon.lang._
 import leon.annotation._
 

--- a/src/test/resources/regression/verification/purescala/valid/RedBlackTree.scala
+++ b/src/test/resources/regression/verification/purescala/valid/RedBlackTree.scala
@@ -1,6 +1,5 @@
 /* Copyright 2009-2015 EPFL, Lausanne */
 
-import scala.collection.immutable.Set
 import leon.annotation._
 import leon.lang._
 

--- a/src/test/resources/regression/verification/purescala/valid/SearchLinkedList.scala
+++ b/src/test/resources/regression/verification/purescala/valid/SearchLinkedList.scala
@@ -1,6 +1,5 @@
 /* Copyright 2009-2015 EPFL, Lausanne */
 
-import scala.collection.immutable.Set
 import leon.lang._
 import leon.annotation._
 

--- a/src/test/resources/regression/verification/purescala/valid/Subtyping1.scala
+++ b/src/test/resources/regression/verification/purescala/valid/Subtyping1.scala
@@ -1,5 +1,7 @@
 /* Copyright 2009-2015 EPFL, Lausanne */
 
+import leon.lang._
+
 object Subtyping1 {
 
   sealed abstract class Tree

--- a/src/test/resources/regression/verification/xlang/invalid/Mean.scala
+++ b/src/test/resources/regression/verification/xlang/invalid/Mean.scala
@@ -1,6 +1,5 @@
 /* Copyright 2009-2015 EPFL, Lausanne */
 
-import scala.collection.immutable.Set
 import leon.annotation._
 import leon.lang._
 

--- a/src/test/resources/regression/verification/xlang/valid/Mean.scala
+++ b/src/test/resources/regression/verification/xlang/valid/Mean.scala
@@ -1,6 +1,5 @@
 /* Copyright 2009-2015 EPFL, Lausanne */
 
-import scala.collection.immutable.Set
 import leon.annotation._
 import leon.lang._
 

--- a/src/test/scala/leon/test/LeonTestSuite.scala
+++ b/src/test/scala/leon/test/LeonTestSuite.scala
@@ -103,7 +103,6 @@ trait LeonTestSuite extends FunSuite with Timeouts with BeforeAndAfterEach {
   }
 
   override def test(name: String, tags: Tag*)(body: => Unit) {
-
     super.test(name, tags: _*) {
       val id = testIdentifier(name)
 

--- a/src/test/scala/leon/test/codegen/CodeGenTests.scala
+++ b/src/test/scala/leon/test/codegen/CodeGenTests.scala
@@ -127,7 +127,8 @@ class CodeGenTests extends test.LeonTestSuite {
 
 
   val code = """
-    
+    import leon.lang._
+
     object simple {
       abstract class Abs
       case class Conc(x : Int) extends Abs

--- a/src/test/scala/leon/test/evaluators/EvaluatorsTests.scala
+++ b/src/test/scala/leon/test/evaluators/EvaluatorsTests.scala
@@ -298,7 +298,8 @@ class EvaluatorsTests extends leon.test.LeonTestSuite {
   }
 
   test("Sets") {
-    val p = """|object Program {
+    val p = """|import leon.lang._
+               |object Program {
                |  sealed abstract class List
                |  case class Nil() extends List
                |  case class Cons(head : Int, tail : List) extends List
@@ -343,20 +344,21 @@ class EvaluatorsTests extends leon.test.LeonTestSuite {
   }
 
   test("Maps") {
-    val p = """|object Program {
-               |sealed abstract class PList
-               |case class PNil() extends PList
-               |case class PCons(headfst : Int, headsnd : Int, tail : PList) extends PList
+    val p = """|import leon.lang._
+               |object Program {
+               |  sealed abstract class PList
+               |  case class PNil() extends PList
+               |  case class PCons(headfst : Int, headsnd : Int, tail : PList) extends PList
                |
-               |def toMap(pl : PList) : Map[Int,Int] = pl match {
-               |  case PNil() => Map.empty[Int,Int]
-               |  case PCons(f,s,xs) => toMap(xs).updated(f, s)
-               |}
+               |  def toMap(pl : PList) : Map[Int,Int] = pl match {
+               |    case PNil() => Map.empty[Int,Int]
+               |    case PCons(f,s,xs) => toMap(xs).updated(f, s)
+               |  }
                |
-               |def finite0() : Map[Int,Int] = Map[Int, Int]()
-               |def finite1() : Map[Int,Int] = Map(1 -> 2)
-               |def finite2() : Map[Int,Int] = Map(2 -> 3, 1 -> 2)
-               |def finite3() : Map[Int,Int] = finite1().updated(2, 3)
+               |  def finite0() : Map[Int,Int] = Map[Int, Int]()
+               |  def finite1() : Map[Int,Int] = Map(1 -> 2)
+               |  def finite2() : Map[Int,Int] = Map(2 -> 3, 1 -> 2)
+               |  def finite3() : Map[Int,Int] = finite1().updated(2, 3)
                |}""".stripMargin
 
     implicit val prog = parseString(p)
@@ -377,7 +379,8 @@ class EvaluatorsTests extends leon.test.LeonTestSuite {
   }
 
   test("Arrays") {
-    val p = """|object Program {
+    val p = """|import leon.lang._
+               |object Program {
                |  def boolArrayRead(bools : Array[Boolean], index : Int) : Boolean = bools(index)
                |
                |  def intArrayRead(ints : Array[Int], index : Int) : Int = ints(index)
@@ -410,7 +413,8 @@ class EvaluatorsTests extends leon.test.LeonTestSuite {
   }
 
   test("Sets and maps of structures") {
-    val p = """|object Program {
+    val p = """|import leon.lang._
+               |object Program {
                |  case class MyPair(x : Int, y : Boolean)
                |
                |  def buildPairCC(x : Int, y : Boolean) : MyPair = MyPair(x,y)
@@ -432,7 +436,8 @@ class EvaluatorsTests extends leon.test.LeonTestSuite {
   }
 
   test("Executing Chooses") {
-    val p = """|object Program {
+    val p = """|import leon.lang._
+               |object Program {
                |  import leon.lang._
                |  import leon.lang.synthesis._
                |
@@ -451,7 +456,8 @@ class EvaluatorsTests extends leon.test.LeonTestSuite {
   test("Infinite Recursion") {
     import leon.codegen._
 
-    val p = """|object Program {
+    val p = """|import leon.lang._
+               |object Program {
                |  import leon.lang._
                |
                |  def c(i : Int) : Int = c(i-1)
@@ -467,7 +473,8 @@ class EvaluatorsTests extends leon.test.LeonTestSuite {
   test("Wrong Contracts") {
     import leon.codegen._
 
-    val p = """|object Program {
+    val p = """|import leon.lang._
+               |object Program {
                |  import leon.lang._
                |
                |  def c(i : Int) : Int = {
@@ -484,7 +491,8 @@ class EvaluatorsTests extends leon.test.LeonTestSuite {
   }
 
   test("Pattern Matching") {
-    val p = """|object Program {
+    val p = """|import leon.lang._
+               |object Program {
                |  abstract class List;
                |  case class Cons(h: Int, t: List) extends List;
                |  case object Nil extends List;

--- a/src/test/scala/leon/test/verification/NewSolversRegression.scala
+++ b/src/test/scala/leon/test/verification/NewSolversRegression.scala
@@ -42,7 +42,4 @@ class NewSolversRegression extends VerificationRegression {
       else Nil
     )
   }
-  
-  test()
-
 }

--- a/src/test/scala/leon/test/verification/PureScalaVerificationRegression.scala
+++ b/src/test/scala/leon/test/verification/PureScalaVerificationRegression.scala
@@ -46,6 +46,4 @@ class PureScalaVerificationRegression extends VerificationRegression {
     )
   }
 
-  test()
-
 }

--- a/src/test/scala/leon/test/verification/VerificationRegression.scala
+++ b/src/test/scala/leon/test/verification/VerificationRegression.scala
@@ -10,6 +10,7 @@ import leon.purescala.Definitions.Program
 import leon.frontends.scalac.ExtractionPhase
 import leon.utils.PreprocessingPhase
 
+import org.scalatest.{Reporter => TestReporter, _}
 
 // If you add another regression test, make sure it contains one object whose name matches the file name
 // This is because we compile all tests from each folder separately.
@@ -29,22 +30,36 @@ trait VerificationRegression extends LeonTestSuite {
   val pipeBack : Pipeline[Program, VerificationReport]
 
   private def mkTest(files: List[String])(block: Output=>Unit) = {
-    val extraction = 
+    val extraction =
       ExtractionPhase andThen
       PreprocessingPhase andThen
       pipeFront
 
-    val ast = extraction.run(createLeonContext(files:_*))(files)
-    val programs = {
-      val (user, lib) = ast.units partition { _.isMainUnit }
-      user map { u => Program(u.id.freshen, u :: lib) }
-    }
-    for (p <- programs; options <- optionVariants) {
-      test(f"${nextInt()}%3d: ${p.id.name} ${options.mkString(" ")}") {
-        val ctx = createLeonContext(options: _*)
-        val report = pipeBack.run(ctx)(p)
-        block(Output(report, ctx.reporter))
+    val ctx = createLeonContext(files:_*)
+
+    try {
+      val ast = extraction.run(ctx)(files)
+      val programs = {
+        val (user, lib) = ast.units partition { _.isMainUnit }
+        user map { u => Program(u.id.freshen, u :: lib) }
       }
+      for (p <- programs; options <- optionVariants) {
+        test(f"${nextInt()}%3d: ${p.id.name} ${options.mkString(" ")}") {
+          val ctx = createLeonContext(options: _*)
+          val report = pipeBack.run(ctx)(p)
+          block(Output(report, ctx.reporter))
+        }
+      }
+    } catch {
+      case _: LeonFatalError =>
+        ctx.reporter match {
+          case sr: TestSilentReporter =>
+            println("Unnexpected Fatal error:")
+            for (e <- sr.lastErrors) {
+              println(" "+e)
+            }
+          case _ =>
+        }
     }
   }
 
@@ -61,7 +76,7 @@ trait VerificationRegression extends LeonTestSuite {
     mkTest(files)(block)
   }
 
-  def test() = {
+  override def run(testName: Option[String], args: Args): Status = {
     forEachFileIn("valid") { output =>
       val Output(report, reporter) = output
       for ((vc, vr) <- report.vrs) {
@@ -79,5 +94,7 @@ trait VerificationRegression extends LeonTestSuite {
       assert(report.totalUnknown === 0,
         "There should not be unknown verification conditions.")
     }
+
+    super.run(testName, args)
   }
 }


### PR DESCRIPTION
We now define our own sets, with only supported operations. Two benefits:

 - Sets are no longer co-variant, meaning Scala's type inference has less liberty to mess around.
 - Only supported operations are defined

Note that importing "leon.lang._" or at least "leon.lang.Set" is mandatory if you want support for Set.