### PR TITLE
Call by name

### DIFF
--- a/src/main/scala/leon/codegen/CompilationUnit.scala
+++ b/src/main/scala/leon/codegen/CompilationUnit.scala
@@ -171,8 +171,7 @@ class CompilationUnit(val ctx: LeonContext,
     case f @ purescala.Extractors.FiniteLambda(dflt, els) =>
       val l = new leon.codegen.runtime.FiniteLambda(exprToJVM(dflt))
 
-      for ((k,v) <- els) {
-        val ks = unwrapTuple(k, f.getType.asInstanceOf[FunctionType].from.size)
+      for ((ks,v) <- els) {
         // Force tuple even with 1/0 elems.
         val kJvm = tupleConstructor.newInstance(ks.map(exprToJVM).toArray).asInstanceOf[leon.codegen.runtime.Tuple]
         val vJvm = exprToJVM(v)

--- a/src/main/scala/leon/frontends/scalac/ASTExtractors.scala
+++ b/src/main/scala/leon/frontends/scalac/ASTExtractors.scala
@@ -407,9 +407,8 @@ trait ASTExtractors {
           true
         case _ => false
       }
-      
     }
-    
+
     object ExDefaultValueFunction{
       /** Matches a function that defines the default value of a parameter */
       def unapply(dd: DefDef): Option[(Symbol, Seq[Symbol], Seq[ValDef], Type, String, Int, Tree)] = {
@@ -418,11 +417,11 @@ trait ASTExtractors {
           case DefDef(_, name, tparams, vparamss, tpt, rhs) if(
             vparamss.size <= 1 && name != nme.CONSTRUCTOR && sym.isSynthetic 
           ) => 
-            
+
             // Split the name into pieces, to find owner of the parameter + param.index
             // Form has to be <owner name>$default$<param index>
             val symPieces = sym.name.toString.reverse.split("\\$", 3).reverseMap(_.reverse)
-            
+
             try {
               if (symPieces(1) != "default" || symPieces(0) == "copy") throw new IllegalArgumentException("")
               val ownerString = symPieces(0)

--- a/src/main/scala/leon/purescala/Constructors.scala
+++ b/src/main/scala/leon/purescala/Constructors.scala
@@ -228,11 +228,10 @@ object Constructors {
    *   ...
    *   else    default
    */
-  def finiteLambda(default: Expr, els: Seq[(Expr, Expr)], inputTypes: Seq[TypeTree]): Lambda = {
+  def finiteLambda(default: Expr, els: Seq[(Seq[Expr], Expr)], inputTypes: Seq[TypeTree]): Lambda = {
     val args = inputTypes map { tpe => ValDef(FreshIdentifier("x", tpe, true)) }
-    val argsExpr = tupleWrap(args map { _.toVariable })
-    val body = els.foldRight(default) { case ((key, value), default) =>
-      IfExpr(Equals(argsExpr, key), value, default)
+    val body = els.foldRight(default) { case ((keys, value), default) =>
+      IfExpr(andJoin((args zip keys).map(p => Equals(p._1.toVariable, p._2))), value, default)
     }
     Lambda(args, body)
   }

--- a/src/main/scala/leon/purescala/Definitions.scala
+++ b/src/main/scala/leon/purescala/Definitions.scala
@@ -47,17 +47,15 @@ object Definitions {
    *  The optional tpe, if present, overrides the type of the underlying Identifier id
    *  This is useful to instantiate argument types of polymorphic functions
    */
-  case class ValDef(id: Identifier, tpe: Option[TypeTree] = None) extends Definition with Typed {
+  case class ValDef(val id: Identifier, val isLazy: Boolean = false) extends Definition with Typed {
     self: Serializable =>
 
-    val getType = tpe getOrElse id.getType
+    val getType = id.getType
 
     var defaultValue : Option[FunDef] = None
-      
+
     def subDefinitions = Seq()
 
-    // Warning: the variable will not have the same type as the ValDef, but 
-    // the Identifier type is enough for all use cases in Leon
     def toVariable : Variable = Variable(id)
 
     setSubDefOwners()
@@ -478,11 +476,10 @@ object Definitions {
       if (typesMap.isEmpty) {
         (fd.params, Map())
       } else {
-        val newParams = fd.params.map {
-          case vd @ ValDef(id, _) =>
-            val newTpe = translated(vd.getType)
-            val newId = FreshIdentifier(id.name, newTpe, true).copiedFrom(id)
-            ValDef(newId).setPos(vd)
+        val newParams = fd.params.map { vd =>
+          val newTpe = translated(vd.getType)
+          val newId = FreshIdentifier(vd.id.name, newTpe, true).copiedFrom(vd.id)
+          vd.copy(id = newId).setPos(vd)
         }
 
         val paramsMap: Map[Identifier, Identifier] = (fd.params zip newParams).map { case (vd1, vd2) => vd1.id -> vd2.id }.toMap

--- a/src/main/scala/leon/purescala/ExprOps.scala
+++ b/src/main/scala/leon/purescala/ExprOps.scala
@@ -1359,8 +1359,8 @@ object ExprOps {
 
           val isType = CaseClassInstanceOf(cct, Variable(on))
 
-          val recSelectors = cct.fields.collect { 
-            case vd if vd.getType == on.getType => vd.id
+          val recSelectors = (cct.classDef.fields zip cct.fieldsTypes).collect { 
+            case (vd, tpe) if tpe == on.getType => vd.id
           }
 
           if (recSelectors.isEmpty) {
@@ -2082,12 +2082,12 @@ object ExprOps {
             substMap += prefix -> Variable(binder)
             substMap += CaseClassInstanceOf(ct, prefix) -> BooleanLiteral(true)
 
-            val subconds = for (f <- ct.fields) yield {
+            val subconds = for ((f,tpe) <- (ct.classDef.fields zip ct.fieldsTypes)) yield {
               val fieldSel = CaseClassSelector(ct, prefix, f.id)
               if (conditions contains fieldSel) {
                 computePatternFor(conditions(fieldSel), fieldSel)
               } else {
-                val b = FreshIdentifier(f.id.name, f.getType, true)
+                val b = FreshIdentifier(f.id.name, tpe, true)
                 substMap += fieldSel -> Variable(b)
                 WildcardPattern(Some(b))
               }

--- a/src/main/scala/leon/purescala/ExprOps.scala
+++ b/src/main/scala/leon/purescala/ExprOps.scala
@@ -710,7 +710,7 @@ object ExprOps {
         })
 
       case CaseClassPattern(_, cct, subps) =>
-        val subExprs = (subps zip cct.fields) map {
+        val subExprs = (subps zip cct.classDef.fields) map {
           case (p, f) => p.binder.map(_.toVariable).getOrElse(CaseClassSelector(cct, in, f.id))
         }
         
@@ -769,8 +769,8 @@ object ExprOps {
               and(CaseClassInstanceOf(cct, in), bind(ob, in))
           }
         case CaseClassPattern(ob, cct, subps) =>
-          assert(cct.fields.size == subps.size)
-          val pairs = cct.fields.map(_.id).toList zip subps.toList
+          assert(cct.classDef.fields.size == subps.size)
+          val pairs = cct.classDef.fields.map(_.id).toList zip subps.toList
           val subTests = pairs.map(p => rec(CaseClassSelector(cct, in, p._1), p._2))
           val together = and(bind(ob, in) +: subTests :_*)
           and(CaseClassInstanceOf(cct, in), together)
@@ -793,10 +793,10 @@ object ExprOps {
     case WildcardPattern(Some(id)) => Map(id -> in)
     case InstanceOfPattern(None, _) => Map.empty
     case InstanceOfPattern(Some(id), _) => Map(id -> in)
-    case CaseClassPattern(b, ccd, subps) => {
-      assert(ccd.fields.size == subps.size)
-      val pairs = ccd.fields.map(_.id).toList zip subps.toList
-      val subMaps = pairs.map(p => mapForPattern(CaseClassSelector(ccd, in, p._1), p._2))
+    case CaseClassPattern(b, cct, subps) => {
+      assert(cct.classDef.fields.size == subps.size)
+      val pairs = cct.classDef.fields.map(_.id).toList zip subps.toList
+      val subMaps = pairs.map(p => mapForPattern(CaseClassSelector(cct, in, p._1), p._2))
       val together = subMaps.foldLeft(Map.empty[Identifier,Expr])(_ ++ _)
       b match {
         case Some(id) => Map(id -> in) ++ together

--- a/src/main/scala/leon/purescala/Types.scala
+++ b/src/main/scala/leon/purescala/Types.scala
@@ -90,10 +90,13 @@ object Types {
         classDef.fields
       } else {
         // !! WARNING !!
-        // vd.id.getType will NOT match vd.tpe, but we kind of need this for selectorID2Index...
-        // See with Etienne about changing this!
-        // @mk Fixed this
-        classDef.fields.map(vd => ValDef(vd.id, Some(instantiateType(vd.getType, tmap))))
+        // vd.id changes but this should not be an issue as selector uses
+        // classDef.params ids which do not change!
+        classDef.fields.map { vd =>
+          val newTpe = instantiateType(vd.getType, tmap)
+          val newId = FreshIdentifier(vd.id.name, newTpe).copiedFrom(vd.id)
+          vd.copy(id = newId).setPos(vd)
+        }
       }
     }
 

--- a/src/main/scala/leon/solvers/smtlib/SMTLIBCVC4Solver.scala
+++ b/src/main/scala/leon/solvers/smtlib/SMTLIBCVC4Solver.scala
@@ -97,9 +97,6 @@ class SMTLIBCVC4Solver(context: LeonContext, program: Program) extends SMTLIBSol
     // FIXME (nicolas)
     // some versions of CVC4 seem to generate array constants with "as const" notation instead of the __array_store_all__
     // one I've witnessed up to now. Don't know why this is happening...
-    case (FunctionApplication(QualifiedIdentifier(SMTIdentifier(SSymbol("const"), _), _), Seq(elem)), ft @ FunctionType(from, to)) =>
-      finiteLambda(fromSMT(elem, to), Seq.empty, from)
-
     case (FunctionApplication(QualifiedIdentifier(SMTIdentifier(SSymbol("const"), _), _), Seq(elem)), RawArrayType(k, v)) =>
       RawArrayValue(k, Map(), fromSMT(elem, v))
 

--- a/src/main/scala/leon/solvers/smtlib/SMTLIBSolver.scala
+++ b/src/main/scala/leon/solvers/smtlib/SMTLIBSolver.scala
@@ -16,7 +16,7 @@ import Definitions._
 
 import _root_.smtlib.common._
 import _root_.smtlib.printer.{RecursivePrinter => SMTPrinter}
-import _root_.smtlib.parser.Commands.{Constructor => SMTConstructor, FunDef => _, Assert => SMTAssert, _}
+import _root_.smtlib.parser.Commands.{Constructor => SMTConstructor, FunDef => SMTFunDef, Assert => SMTAssert, _}
 import _root_.smtlib.parser.Terms.{
   ForAll => SMTForall,
   Exists => SMTExists,
@@ -26,6 +26,7 @@ import _root_.smtlib.parser.Terms.{
 }
 import _root_.smtlib.parser.CommandsResponses.{Error => ErrorResponse, _}
 import _root_.smtlib.theories._
+import _root_.smtlib.theories.Core.{ITE, Equals => SMTEquals, And => SMTAnd}
 import _root_.smtlib.{Interpreter => SMTInterpreter}
 
 
@@ -65,9 +66,7 @@ abstract class SMTLIBSolver(val context: LeonContext,
     new java.io.FileWriter(s"vcs/$targetName-$file-$n.smt2", false)
   } else null
 
-
   /* Interruptible interface */
-
   protected var interrupted = false
 
   context.interruptManager.registerForInterrupts(this)
@@ -112,6 +111,7 @@ abstract class SMTLIBSolver(val context: LeonContext,
   protected val genericValues = new IncrementalBijection[GenericValue, SSymbol]()
   protected val sorts         = new IncrementalBijection[TypeTree, Sort]()
   protected val functions     = new IncrementalBijection[TypedFunDef, SSymbol]()
+  protected val lambdas       = new IncrementalBijection[FunctionType, SSymbol]()
   protected val errors        = new IncrementalBijection[Unit, Boolean]()
   protected def hasError = errors.getB(()) contains true
   protected def addError() = errors += () -> true
@@ -219,9 +219,6 @@ abstract class SMTLIBSolver(val context: LeonContext,
     case RawArrayType(from, to) =>
       r
 
-    case ft @ FunctionType(from, to) =>
-      finiteLambda(r.default, r.elems.toSeq, from)
-
     case MapType(from, to) =>
       // We expect a RawArrayValue with keys in from and values in Option[to],
       // with default value == None
@@ -254,7 +251,7 @@ abstract class SMTLIBSolver(val context: LeonContext,
           declareMapSort(from, to)
 
         case FunctionType(from, to) =>
-          Sort(SMTIdentifier(SSymbol("Array")), Seq(declareSort(tupleTypeWrap(from)), declareSort(to)))
+          Ints.IntSort()
 
         case TypeParameter(id) =>
           val s = id2sym(id)
@@ -476,8 +473,20 @@ abstract class SMTLIBSolver(val context: LeonContext,
     f
   }
 
-  /* Translate a Leon Expr to an SMTLIB term */
+  protected def declareLambda(tpe: FunctionType): SSymbol = {
+    lambdas.cachedB(tpe) {
+      val id = FreshIdentifier("dynLambda")
+      val s = id2sym(id)
+      sendCommand(DeclareFun(
+        s,
+        (IntegerType +: tpe.from).map(declareSort),
+        declareSort(tpe.to)
+      ))
+      s
+    }
+  }
 
+  /* Translate a Leon Expr to an SMTLIB term */
   protected def toSMT(e: Expr)(implicit bindings: Map[Identifier, Term]): Term = {
     e match {
       case Variable(id) =>
@@ -623,7 +632,10 @@ abstract class SMTLIBSolver(val context: LeonContext,
        * ===== Everything else =====
        */
       case ap @ Application(caller, args) =>
-        ArraysEx.Select(toSMT(caller), toSMT(tupleWrap(args)))
+        FunctionApplication(
+          declareLambda(caller.getType.asInstanceOf[FunctionType]),
+          (caller +: args).map(toSMT)
+        )
 
       case Not(u) => Core.Not(toSMT(u))
       case UMinus(u) => Ints.Neg(toSMT(u))
@@ -736,6 +748,66 @@ abstract class SMTLIBSolver(val context: LeonContext,
           CaseClass(cct, Nil)
         case t =>
           unsupported("woot? for a single constructor for non-case-object: "+t)
+      }
+
+    case (SNumeral(n), ft @ FunctionType(from, to)) =>
+      val dynLambda = lambdas.toB(ft)
+      letDefs.get(dynLambda) match {
+        case Some(DefineFun(SMTFunDef(a, SortedVar(dispatcher, dkind) +: args, rkind, body))) =>
+
+          object EQ {
+            def unapply(t: Term): Option[(Term,Term)] = t match {
+              case SMTEquals(e1, e2) => Some((e1, e2))
+              case FunctionApplication(f, Seq(e1, e2)) if f.toString == "=" => Some((e1, e2))
+              case _ => None
+            }
+          }
+
+          object Num {
+            def unapply(t: Term): Option[BigInt] = t match {
+              case SNumeral(n) => Some(n)
+              case FunctionApplication(f, Seq(SNumeral(n))) if f.toString == "-" => Some(n)
+              case _ => None
+            }
+          }
+
+          val d = symbolToQualifiedId(dispatcher)
+          def dispatch(t: Term): Term = t match {
+            case ITE(EQ(di, Num(ni)), thenn, elze) if di == d =>
+              if (ni == n) thenn else dispatch(elze)
+            case ITE(SMTAnd(EQ(di, Num(ni)), _), thenn, elze) if di == d =>
+              if (ni == n) thenn else dispatch(elze)
+            case _ => t
+          }
+
+          def extract(t: Term): Expr = {
+            def recCond(term: Term, index: Int): Seq[Expr] = term match {
+              case SMTAnd(e1, e2) =>
+                val e1s = recCond(e1, index)
+                e1s ++ recCond(e2, index + e1s.size)
+              case EQ(e1, e2) =>
+                recCond(e2, index)
+              case _ => Seq(fromSMT(term, from(index)))
+            }
+
+            def recCases(term: Term, matchers: Seq[Expr]): Seq[(Seq[Expr], Expr)] = term match {
+              case ITE(cond, thenn, elze) =>
+                val cs = recCond(cond, matchers.size)
+                recCases(thenn, matchers ++ cs) ++ recCases(elze, matchers)
+              case _ => Seq(matchers -> fromSMT(term, to))
+            }
+
+            val cases = recCases(t, Seq.empty)
+            val (default, rest) = cases.partition(_._1.isEmpty)
+
+            assert(default.size == 1 && rest.forall(_._1.size == from.size))
+            finiteLambda(default.head._2, rest, from)
+          }
+
+          val lambdaTerm = dispatch(body)
+          val lambda = extract(lambdaTerm)
+          lambda
+        case None => unsupported("Unknown function ref: " + n)
       }
 
     case (SimpleSymbol(s), tpe) if lets contains s =>
@@ -854,25 +926,38 @@ abstract class SMTLIBSolver(val context: LeonContext,
   }
 
   override def getModel: Map[Identifier, Expr] = {
-    val syms = variables.bSet.toList
-    if (syms.isEmpty) {
-      Map()
-    } else {
-      val cmd: Command =
-        GetValue(syms.head,
-          syms.tail.map(s => QualifiedIdentifier(SMTIdentifier(s)))
-        )
+    val cmd = GetModel()
 
+    val res = sendCommand(cmd)
 
-      val GetValueResponseSuccess(valuationPairs) = sendCommand(cmd)
-
-      valuationPairs.collect {
-        case (SimpleSymbol(sym), value) if variables.containsB(sym) =>
-          val id = variables.toA(sym)
-
-          (id, fromSMT(value, id.getType)(Map(), Map()))
-      }.toMap
+    val smodel: Seq[SExpr] = res match {
+      case GetModelResponseSuccess(model) => model
+      case _ => Nil
     }
+
+    var modelFunDefs = Map[SSymbol, DefineFun]()
+
+    // first-pass to gather functions
+    for (me <- smodel) me match {
+      case me @ DefineFun(SMTFunDef(a, args, _, _)) if args.nonEmpty =>
+        modelFunDefs += a -> me
+      case _ =>
+    }
+
+    var model = Map[Identifier, Expr]()
+
+    for (me <- smodel) me match {
+      case DefineFun(SMTFunDef(s, args, kind, e)) if args.isEmpty =>
+        variables.getA(s) match {
+          case Some(id) =>
+            // EK: this is a little hack, we pass models for array functions as let-defs
+            model += id -> fromSMT(e, id.getType)(Map(), modelFunDefs)
+          case _ =>
+        }
+      case _ =>
+    }
+
+    model
   }
 
   override def push(): Unit = {
@@ -882,6 +967,7 @@ abstract class SMTLIBSolver(val context: LeonContext,
     variables.push()
     genericValues.push()
     sorts.push()
+    lambdas.push()
     functions.push()
     errors.push()
     sendCommand(Push(1))
@@ -896,6 +982,7 @@ abstract class SMTLIBSolver(val context: LeonContext,
     variables.pop()
     genericValues.pop()
     sorts.pop()
+    lambdas.pop()
     functions.pop()
     errors.pop()
 

--- a/src/main/scala/leon/solvers/templates/LambdaManager.scala
+++ b/src/main/scala/leon/solvers/templates/LambdaManager.scala
@@ -108,7 +108,7 @@ class LambdaManager[T](encoder: TemplateEncoder[T]) {
     (clauses, callBlockers, appBlockers)
   }
 
-  def instantiateLambda(idT: T, template: LambdaTemplate[T]): Instantiation[T] = {
+  def registerLambda(idT: T, template: LambdaTemplate[T]): Instantiation[T] = {
     val eqClauses = equalityClauses(idT, template)
     val (clauses, blockers, apps) = instantiate(Map.empty, Map(idT -> template))
     (eqClauses ++ clauses, blockers, apps)

--- a/src/main/scala/leon/synthesis/rules/ADTDual.scala
+++ b/src/main/scala/leon/synthesis/rules/ADTDual.scala
@@ -19,10 +19,10 @@ case object ADTDual extends NormalizingRule("ADTDual") {
 
     val (toRemove, toAdd) = exprs.collect {
       case eq @ Equals(cc @ CaseClass(ct, args), e) if (variablesOf(e) -- as).isEmpty && (variablesOf(cc) & xs).nonEmpty =>
-        (eq, CaseClassInstanceOf(ct, e) +: (ct.fields zip args).map{ case (vd, ex) => Equals(ex, CaseClassSelector(ct, e, vd.id)) } )
+        (eq, CaseClassInstanceOf(ct, e) +: (ct.classDef.fields zip args).map{ case (vd, ex) => Equals(ex, CaseClassSelector(ct, e, vd.id)) } )
 
       case eq @ Equals(e, cc @ CaseClass(ct, args)) if (variablesOf(e) -- as).isEmpty && (variablesOf(cc) & xs).nonEmpty =>
-        (eq, CaseClassInstanceOf(ct, e) +: (ct.fields zip args).map{ case (vd, ex) => Equals(ex, CaseClassSelector(ct, e, vd.id)) } )
+        (eq, CaseClassInstanceOf(ct, e) +: (ct.classDef.fields zip args).map{ case (vd, ex) => Equals(ex, CaseClassSelector(ct, e, vd.id)) } )
     }.unzip
 
     if (toRemove.nonEmpty) {

--- a/src/main/scala/leon/synthesis/rules/ADTSplit.scala
+++ b/src/main/scala/leon/synthesis/rules/ADTSplit.scala
@@ -73,7 +73,7 @@ case object ADTSplit extends Rule("ADT Split.") {
 
             val cases = for ((sol, (cct, problem, pattern)) <- sols zip subInfo) yield {
               if (sol.pre != BooleanLiteral(true)) {
-                val substs = (for ((field,arg) <- cct.fields zip problem.as ) yield {
+                val substs = (for ((field,arg) <- cct.classDef.fields zip problem.as ) yield {
                   (arg, CaseClassSelector(cct, id.toVariable, field.id))
                 }).toMap
                 globalPre ::= and(CaseClassInstanceOf(cct, Variable(id)), replaceFromIDs(substs, sol.pre)) 

--- a/src/main/scala/leon/verification/InductionTactic.scala
+++ b/src/main/scala/leon/verification/InductionTactic.scala
@@ -21,7 +21,7 @@ class InductionTactic(vctx: VerificationContext) extends DefaultTactic(vctx) {
   }
 
   private def selectorsOfParentType(parentType: ClassType, cct: CaseClassType, expr: Expr): Seq[Expr] = {
-    val childrenOfSameType = cct.fields.filter(_.getType == parentType)
+    val childrenOfSameType = (cct.classDef.fields zip cct.fieldsTypes).collect { case (vd, tpe) if tpe == parentType => vd }
     for (field <- childrenOfSameType) yield {
       CaseClassSelector(cct, expr, field.id)
     }

--- a/src/test/resources/regression/verification/purescala/invalid/CallByName1.scala
+++ b/src/test/resources/regression/verification/purescala/invalid/CallByName1.scala
@@ -1,0 +1,17 @@
+import leon.lang._
+
+object CallByName1 {
+  def byName1(i: Int, a: => Int): Int = {
+    if (i > 0) a + 1
+    else 0
+  }
+
+  def byName2(i: Int, a: => Int): Int = {
+    if (i > 0) byName1(i - 1, a) + 2
+    else 0
+  }
+
+  def test(): Boolean = {
+    byName1(1, byName2(3, 0)) == 0 && byName1(1, byName2(3, 0)) == 1
+  }.holds
+}

--- a/src/test/resources/regression/verification/purescala/valid/CallByName1.scala
+++ b/src/test/resources/regression/verification/purescala/valid/CallByName1.scala
@@ -1,0 +1,9 @@
+import leon.lang._
+
+object CallByName1 {
+  def add(a: => Int, b: => Int): Int = a + b
+
+  def test(): Int = {
+    add(1,2)
+  } ensuring (_ == 3)
+}


### PR DESCRIPTION
- Introduce call-by-name arguments into Leon
- Reworked lambdas to avoid known issue with finite image domains
- Reworked ValDefs to not introduce potentially inconsistent types

- Changed the SMTLIBSolver to use get-model in all cases
