### PR TITLE
Some improvements

### DIFF
--- a/src/main/scala/leon/Main.scala
+++ b/src/main/scala/leon/Main.scala
@@ -224,7 +224,7 @@ object Main {
     val doWatch = ctx.findOptionOrDefault(SharedOptions.optWatch)
 
     if (doWatch) {
-      val watcher = new FilesWatcher(ctx, ctx.files)
+      val watcher = new FilesWatcher(ctx, ctx.files ++ Build.libFiles.map{ new java.io.File(_)})
       watcher.onChange {
         execute(args, ctx)
       }

--- a/src/main/scala/leon/verification/DefaultTactic.scala
+++ b/src/main/scala/leon/verification/DefaultTactic.scala
@@ -33,8 +33,8 @@ class DefaultTactic(vctx: VerificationContext) extends Tactic(vctx) {
             case ((fi @ FunctionInvocation(tfd, args), pre), path) =>
               val pre2 = replaceFromIDs((tfd.params.map(_.id) zip args).toMap, pre)
               val vc = implies(and(precOrTrue(fd), path), pre2)
-
-              VC(vc, fd, VCKinds.Info(VCKinds.Precondition, s"call $fi"), this).setPos(fi)
+              val fiS = exprToShortString(fi)
+              VC(vc, fd, VCKinds.Info(VCKinds.Precondition, s"call $fiS"), this).setPos(fi)
           }
 
         case None =>

--- a/src/main/scala/leon/verification/InductionTactic.scala
+++ b/src/main/scala/leon/verification/InductionTactic.scala
@@ -77,7 +77,10 @@ class InductionTactic(vctx: VerificationContext) extends DefaultTactic(vctx) {
 
               val vc = implies(and(CaseClassInstanceOf(cct, arg.toVariable), precOrTrue(fd), path), implies(andJoin(subCases), replace((tfd.params.map(_.toVariable) zip args).toMap, pre)))
 
-              VC(vc, fd, VCKinds.Info(VCKinds.Precondition, "call $fi, ind. on $arg / ${cct.classDef.id}"), this).setPos(fi)
+              // Crop the call to display it properly
+              val fiS = exprToShortString(fi)
+
+              VC(vc, fd, VCKinds.Info(VCKinds.Precondition, "call $fiS, ind. on ($arg : ${cct.classDef.id)}"), this).setPos(fi)
             }
         }
 

--- a/src/main/scala/leon/verification/Tactic.scala
+++ b/src/main/scala/leon/verification/Tactic.scala
@@ -31,4 +31,11 @@ abstract class Tactic(vctx: VerificationContext) {
   protected def collectWithPC[T](f: PartialFunction[Expr, T])(expr: Expr): Seq[(T, Expr)] = {
     CollectorWithPaths(f).traverse(expr)
   }
+
+  protected def exprToShortString(e: Expr) = {
+    // Crop the call to display it properly
+    val eS = e.toString
+    val s = eS.takeWhile(_ != '\n').take(35)
+    if (s == eS) s else s ++ " ..."
+  }
 }

--- a/testcases/repair/Heap/Heap.scala
+++ b/testcases/repair/Heap/Heap.scala
@@ -7,7 +7,7 @@
 import leon.lang._
 import leon.collection._
 
-object HeapSort {
+object Heaps {
  
   sealed abstract class Heap {
     val rank : Int = this match {

--- a/testcases/repair/Heap/Heap1.scala
+++ b/testcases/repair/Heap/Heap1.scala
@@ -7,7 +7,7 @@
 import leon.lang._
 import leon.collection._
 
-object HeapSort {
+object Heaps {
  
   sealed abstract class Heap {
     val rank : Int = this match {

--- a/testcases/repair/Heap/Heap10.scala
+++ b/testcases/repair/Heap/Heap10.scala
@@ -7,7 +7,7 @@
 import leon.lang._
 import leon.collection._
 
-object HeapSort {
+object Heaps {
  
   sealed abstract class Heap {
     val rank : Int = this match {

--- a/testcases/repair/Heap/Heap2.scala
+++ b/testcases/repair/Heap/Heap2.scala
@@ -7,7 +7,7 @@
 import leon.lang._
 import leon.collection._
 
-object HeapSort {
+object Heaps {
  
   sealed abstract class Heap {
     val rank : Int = this match {

--- a/testcases/repair/Heap/Heap3.scala
+++ b/testcases/repair/Heap/Heap3.scala
@@ -7,7 +7,7 @@
 import leon.lang._
 import leon.collection._
 
-object HeapSort {
+object Heaps {
  
   sealed abstract class Heap {
     val rank : Int = this match {

--- a/testcases/repair/Heap/Heap4.scala
+++ b/testcases/repair/Heap/Heap4.scala
@@ -7,7 +7,7 @@
 import leon.lang._
 import leon.collection._
 
-object HeapSort {
+object Heaps {
  
   sealed abstract class Heap {
     val rank : Int = this match {

--- a/testcases/repair/Heap/Heap5.scala
+++ b/testcases/repair/Heap/Heap5.scala
@@ -7,8 +7,8 @@
 import leon.lang._
 import leon.collection._
 
-object HeapSort {
- 
+object Heaps {
+   
   sealed abstract class Heap {
     val rank : Int = this match {
       case Leaf() => 0

--- a/testcases/repair/Heap/Heap6.scala
+++ b/testcases/repair/Heap/Heap6.scala
@@ -7,7 +7,7 @@
 import leon.lang._
 import leon.collection._
 
-object HeapSort {
+object Heaps {
  
   sealed abstract class Heap {
     val rank : Int = this match {

--- a/testcases/repair/Heap/Heap7.scala
+++ b/testcases/repair/Heap/Heap7.scala
@@ -7,7 +7,7 @@
 import leon.lang._
 import leon.collection._
 
-object HeapSort {
+object Heaps {
  
   sealed abstract class Heap {
     val rank : Int = this match {

--- a/testcases/repair/Heap/Heap8.scala
+++ b/testcases/repair/Heap/Heap8.scala
@@ -7,7 +7,7 @@
 import leon.lang._
 import leon.collection._
 
-object HeapSort {
+object Heaps {
  
   sealed abstract class Heap {
     val rank : Int = this match {

--- a/testcases/repair/Heap/Heap9.scala
+++ b/testcases/repair/Heap/Heap9.scala
@@ -7,7 +7,7 @@
 import leon.lang._
 import leon.collection._
 
-object HeapSort {
+object Heaps {
  
   sealed abstract class Heap {
     val rank : Int = this match {


### PR DESCRIPTION
- FilesWatcher now also watches library files.
- Preconditions are cropped when printed inside a verification table.
- objects in repair benchmarks should not be named HeapSort
