### PR TITLE
track dependencies on unapply patterns in CallGraph

### DIFF
--- a/src/test/resources/regression/verification/isabelle/valid/Unapply.scala
+++ b/src/test/resources/regression/verification/isabelle/valid/Unapply.scala
@@ -1,0 +1,15 @@
+import leon.annotation._
+import leon.collection._
+import leon.lang._
+
+object Unapply {
+
+  @isabelle.proof(method = """(cases "<var xs>", auto)""")
+  def check[A](xs: List[A]) = {
+    xs match {
+      case Nil() => true
+      case _ :: _ => true
+    }
+  }.holds
+
+}

--- a/src/test/scala/leon/integration/purescala/CallGraphSuite.scala
+++ b/src/test/scala/leon/integration/purescala/CallGraphSuite.scala
@@ -1,0 +1,29 @@
+/* Copyright 2009-2015 EPFL, Lausanne */
+
+package leon.integration.purescala
+
+import leon.test._
+
+import leon._
+import leon.purescala.Definitions._
+import leon.utils._
+
+class CallGraphSuite extends LeonTestSuiteWithProgram with helpers.ExpressionsDSL {
+
+  val sources = List(
+    """object Matches {
+      |  import leon.collection._
+      |  def aMatch(a: List[Int]) = a match {
+      |    case _ :: _ => 0
+      |  }
+      |}""".stripMargin
+  )
+
+  test("CallGraph tracks dependency to unapply pattern") { implicit fix =>
+    val fd1 = funDef("Matches.aMatch")
+    val fd2 = funDef("leon.collection.::.unapply")
+
+    assert(implicitly[Program].callGraph.calls(fd1, fd2))
+  }
+
+}


### PR DESCRIPTION
Required by Isabelle. Fixes #143.

Previously, `matchToIfThenElse` could suddenly "introduce" hitherto unknown function calls, because it translates unapply patterns to function calls. The updated algorithm in `CallGraph` now takes these "hidden" calls into account.