### PR TITLE
Fixed code generation for Windows.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -91,7 +91,7 @@ sourceGenerators in Compile <+= Def.task {
   IO.write(build, s"""|package leon
                       |
                       |object Build {
-                      |  val baseDirectory = \"${baseDirectory.value.toString}\"
+                      |  val baseDirectory = \"\"\"${baseDirectory.value.toString}\"\"\"
                       |  val libFiles = List(
                       |    ${libFiles.mkString("\"\"\"", "\"\"\",\n    \"\"\"", "\"\"\"")}
                       |  )


### PR DESCRIPTION
The code generated by the `build.sbt` could not work on Windows since paths such as "c:\User " have to be enclosed in triple quotes.
