### PR TITLE
Add support for (basic) conversion to C

### DIFF
--- a/.larabot.conf
+++ b/.larabot.conf
@@ -2,6 +2,7 @@ commands = [
     "sbt -batch test"
     "sbt -batch integration:test"
     "sbt -batch regression:test"
+    "sbt -batch genc:test"
 ]
 
 trusted = [

--- a/build.sbt
+++ b/build.sbt
@@ -141,6 +141,14 @@ parallelExecution in IsabelleTest := false
 
 fork in IsabelleTest := true
 
+// GenC Tests
+lazy val GenCTest = config("genc") extend(Test)
+
+testOptions in GenCTest := Seq(Tests.Argument("-oDF"), Tests.Filter(_ startsWith "leon.genc."))
+
+parallelExecution in GenCTest := false
+
+
 
 def ghProject(repo: String, version: String) = RootProject(uri(s"${repo}#${version}"))
 
@@ -148,9 +156,11 @@ lazy val bonsai      = ghProject("git://github.com/colder/bonsai.git",     "10ea
 lazy val scalaSmtLib = ghProject("git://github.com/regb/scala-smtlib.git", "372bb14d0c84953acc17f9a7e1592087adb0a3e1")
 
 lazy val root = (project in file(".")).
-  configs(RegressionTest, IsabelleTest, IntegrTest).
+  configs(RegressionTest, IsabelleTest, GenCTest, IntegrTest).
   dependsOn(bonsai, scalaSmtLib).
   settings(inConfig(RegressionTest)(Defaults.testTasks ++ testSettings): _*).
   settings(inConfig(IntegrTest)(Defaults.testTasks ++ testSettings): _*).
   settings(inConfig(IsabelleTest)(Defaults.testTasks ++ testSettings): _*).
+  settings(inConfig(GenCTest)(Defaults.testTasks ++ testSettings): _*).
   settings(inConfig(Test)(Defaults.testTasks ++ testSettings): _*)
+

--- a/src/main/scala/leon/Main.scala
+++ b/src/main/scala/leon/Main.scala
@@ -27,7 +27,9 @@ object Main {
       solvers.isabelle.AdaptationPhase,
       solvers.isabelle.IsabellePhase,
       transformations.InstrumentationPhase,
-      invariant.engine.InferInvariantsPhase)
+      invariant.engine.InferInvariantsPhase,
+      genc.GenerateCPhase,
+      genc.CFileOutputPhase)
   }
 
   // Add whatever you need here.
@@ -53,9 +55,10 @@ object Main {
     val optHelp        = LeonFlagOptionDef("help",        "Show help message",                                         false)
     val optInstrument  = LeonFlagOptionDef("instrument",  "Instrument the code for inferring time/depth/stack bounds", false)
     val optInferInv    = LeonFlagOptionDef("inferInv",    "Infer invariants from (instrumented) the code",             false)
+    val optGenc        = LeonFlagOptionDef("genc",        "Generate C code",                                           false)
 
     override val definedOptions: Set[LeonOptionDef[Any]] =
-      Set(optTermination, optRepair, optSynthesis, optIsabelle, optNoop, optHelp, optEval, optVerify, optInstrument, optInferInv)
+      Set(optTermination, optRepair, optSynthesis, optIsabelle, optNoop, optHelp, optEval, optVerify, optInstrument, optInferInv, optGenc)
   }
 
   lazy val allOptions: Set[LeonOptionDef[Any]] = allComponents.flatMap(_.definedOptions)
@@ -151,6 +154,8 @@ object Main {
     import repair.RepairPhase
     import evaluators.EvaluationPhase
     import solvers.isabelle.IsabellePhase
+    import genc.GenerateCPhase
+    import genc.CFileOutputPhase
     import MainComponent._
     import invariant.engine.InferInvariantsPhase
     import transformations.InstrumentationPhase
@@ -163,10 +168,16 @@ object Main {
     val isabelleF    = ctx.findOptionOrDefault(optIsabelle)
     val terminationF = ctx.findOptionOrDefault(optTermination)
     val verifyF      = ctx.findOptionOrDefault(optVerify)
+    val gencF        = ctx.findOptionOrDefault(optGenc)
     val evalF        = ctx.findOption(optEval).isDefined
     val inferInvF    = ctx.findOptionOrDefault(optInferInv)
     val instrumentF  = ctx.findOptionOrDefault(optInstrument)
     val analysisF    = verifyF && terminationF
+
+    // Check consistency in options
+    if (gencF && !xlangF) {
+      ctx.reporter.fatalError("Generating C code with --genc requires --xlang")
+    }
 
     if (helpF) {
       displayVersion(ctx.reporter)
@@ -175,7 +186,7 @@ object Main {
       val pipeBegin: Pipeline[List[String], Program] =
         ClassgenPhase andThen
         ExtractionPhase andThen
-        new PreprocessingPhase(xlangF)
+        new PreprocessingPhase(xlangF, gencF)
 
       val verification = if (xlangF) VerificationPhase andThen FixReportLabels else VerificationPhase
 
@@ -189,6 +200,7 @@ object Main {
         else if (evalF) EvaluationPhase
         else if (inferInvF) InferInvariantsPhase
         else if (instrumentF) InstrumentationPhase andThen FileOutputPhase
+        else if (gencF) GenerateCPhase andThen CFileOutputPhase
         else verification
       }
 

--- a/src/main/scala/leon/frontends/scalac/CodeExtraction.scala
+++ b/src/main/scala/leon/frontends/scalac/CodeExtraction.scala
@@ -153,7 +153,7 @@ trait CodeExtraction extends ASTExtractors {
     }
 
     private def isIgnored(s: Symbol) = {
-      (annotationsOf(s) contains "ignore") || s.fullName.toString.endsWith(".main")
+      (annotationsOf(s) contains "ignore")
     }
 
     private def isLibrary(u: CompilationUnit) = Build.libFiles contains u.source.file.absolute.path

--- a/src/main/scala/leon/genc/CAST.scala
+++ b/src/main/scala/leon/genc/CAST.scala
@@ -18,6 +18,11 @@ object CAST { // C Abstract Syntax Tree
   /* ------------------------------------------------------------ Types ----- */
   abstract class Type(val rep: String) extends Tree {
     override def toString = rep
+
+    def mutable: Type = this match {
+      case Const(typ) => typ.mutable
+      case _          => this
+    }
   }
 
   /* Type Modifiers */
@@ -149,7 +154,7 @@ object CAST { // C Abstract Syntax Tree
       val name = Id("__leon_tuple_" + bases.mkString("_") + "_t")
 
       val fields = bases.zipWithIndex map {
-        case (typ, idx) => Var(getNthId(idx + 1), typ)
+        case (typ, idx) => Val(getNthId(idx + 1), typ)
       }
 
       Struct(name, fields)

--- a/src/main/scala/leon/genc/CAST.scala
+++ b/src/main/scala/leon/genc/CAST.scala
@@ -154,7 +154,7 @@ object CAST { // C Abstract Syntax Tree
       val name = Id("__leon_tuple_" + bases.mkString("_") + "_t")
 
       val fields = bases.zipWithIndex map {
-        case (typ, idx) => Val(getNthId(idx + 1), typ)
+        case (typ, idx) => Var(getNthId(idx + 1), typ)
       }
 
       Struct(name, fields)

--- a/src/main/scala/leon/genc/CAST.scala
+++ b/src/main/scala/leon/genc/CAST.scala
@@ -73,7 +73,7 @@ object CAST { // C Abstract Syntax Tree
   }
 
   case class Assign(lhs: Stmt, rhs: Stmt) extends Stmt {
-    require(rhs.isValue)
+    require(lhs.isValue && rhs.isValue)
   }
 
   // Note: we don't need to differentiate between specific
@@ -185,10 +185,10 @@ object CAST { // C Abstract Syntax Tree
     }
 
     // True if statement can be used as a value
-    def isValue = isLiteral || {
+    def isValue: Boolean = isLiteral || {
       stmt match {
         //case _: Assign => true it's probably the case but for now let's ignore it
-        case c: Compound            => c.stmts.size == 1
+        case c: Compound            => c.stmts.size == 1 && c.stmts.head.isValue
         case _: UnOp                => true
         case _: MultiOp             => true
         case _: SubscriptOp         => true

--- a/src/main/scala/leon/genc/CAST.scala
+++ b/src/main/scala/leon/genc/CAST.scala
@@ -1,0 +1,275 @@
+/* Copyright 2009-2015 EPFL, Lausanne */
+
+package leon
+package genc
+
+import utils.UniqueCounter
+
+/*
+ * Here are defined classes used to represent AST of C programs.
+ */
+
+object CAST { // C Abstract Syntax Tree
+
+  sealed abstract class Tree
+  case object NoTree extends Tree
+
+
+  /* ------------------------------------------------------------ Types ----- */
+  abstract class Type(val rep: String) extends Tree {
+    override def toString = rep
+  }
+
+  /* Type Modifiers */
+  case class Const(typ: Type) extends Type(s"$typ const")
+  case class Pointer(typ: Type) extends Type(s"$typ*")
+
+  /* Primitive Types */
+  case object Int32 extends Type("int32_t") // Requires <stdint.h>
+  case object Bool extends Type("bool")     // Requires <stdbool.h>
+  case object Void extends Type("void")
+
+  /* Compound Types */
+  case class Struct(id: Id, fields: Seq[Var]) extends Type(id.name)
+
+
+  /* --------------------------------------------------------- Literals ----- */
+  case class IntLiteral(v: Int) extends Stmt
+  case class BoolLiteral(b: Boolean) extends Stmt
+
+
+  /* ----------------------------------------------------- Definitions  ----- */
+  abstract class Def extends Tree
+
+  case class Prog(structs: Seq[Struct], functions: Seq[Fun]) extends Def
+
+  case class Fun(id: Id, retType: Type, params: Seq[Var], body: Stmt) extends Def
+
+  case class Id(name: String) extends Def {
+    // `|` is used as the margin delimiter and can cause trouble in some situations
+    def fixMargin =
+      if (name.size > 0 && name(0) == '|') "| " + name
+      else name
+  }
+
+  case class Var(id: Id, typ: Type) extends Def {
+    def access = AccessVar(id)
+  }
+
+  /* ----------------------------------------------------------- Stmts  ----- */
+  abstract class Stmt extends Tree
+  case object NoStmt extends Stmt
+
+  case class Compound(stmts: Seq[Stmt]) extends Stmt
+
+  case class Assert(pred: Stmt, error: Option[String]) extends Stmt { // Requires <assert.h>
+    require(pred.isValue)
+  }
+
+  case class DeclVar(x: Var) extends Stmt
+
+  case class DeclInitVar(x: Var, value: Stmt) extends Stmt {
+    require(value.isValue)
+  }
+
+  case class Assign(lhs: Stmt, rhs: Stmt) extends Stmt {
+    require(rhs.isValue)
+  }
+
+  // Note: we don't need to differentiate between specific
+  // operators so we only keep track of the "kind" of operator
+  // with an Id.
+  case class UnOp(op: Id, rhs: Stmt) extends Stmt {
+    require(rhs.isValue)
+  }
+
+  case class MultiOp(op: Id, stmts: Seq[Stmt]) extends Stmt {
+    require(stmts.length > 1 && stmts.forall { _.isValue })
+  }
+
+  case class SubscriptOp(ptr: Stmt, idx: Stmt) extends Stmt {
+    require(ptr.isValue && idx.isValue)
+  }
+
+  case object Break extends Stmt
+
+  case class Return(stmt: Stmt) extends Stmt {
+    require(stmt.isValue)
+  }
+
+  case class IfElse(cond: Stmt, thn: Stmt, elze: Stmt) extends Stmt {
+    require(cond.isValue)
+  }
+
+  case class While(cond: Stmt, body: Stmt) extends Stmt {
+    require(cond.isValue)
+  }
+
+  case class AccessVar(id: Id) extends Stmt
+  case class AccessRef(id: Id) extends Stmt
+  case class AccessAddr(id: Id) extends Stmt
+  case class AccessField(struct: Stmt, field: Id) extends Stmt {
+    require(struct.isValue)
+  }
+
+  case class Call(id: Id, args: Seq[Stmt]) extends Stmt {
+    require(args forall { _.isValue })
+  }
+
+  case class StructInit(args: Seq[(Id, Stmt)], struct: Struct) extends Stmt {
+    require(args forall { _._2.isValue })
+  }
+
+  case class ArrayInit(length: Stmt, valueType: Type, defaultValue: Stmt) extends Stmt {
+    require(length.isValue && defaultValue.isValue)
+  }
+
+  case class ArrayInitWithValues(valueType: Type, values: Seq[Stmt]) extends Stmt {
+    require(values forall { _.isValue })
+
+    lazy val length = values.length
+  }
+
+
+  /* -------------------------------------------------------- Factories ----- */
+  object Op {
+    def apply(op: String, rhs: Stmt) = UnOp(Id(op), rhs)
+    def apply(op: String, rhs: Stmt, lhs: Stmt) = MultiOp(Id(op), rhs :: lhs :: Nil)
+    def apply(op: String, stmts: Seq[Stmt]) = MultiOp(Id(op), stmts)
+  }
+
+  object Val {
+    def apply(id: Id, typ: Type) = typ match {
+      case Const(_) => Var(id, typ) // avoid const of const
+      case _        => Var(id, Const(typ))
+    }
+  }
+
+  /* "Templatetized" Types */
+  object Tuple {
+    def apply(bases: Seq[Type]) = {
+      val name = Id("__leon_tuple_" + bases.mkString("_") + "_t")
+
+      val fields = bases.zipWithIndex map {
+        case (typ, idx) => Var(getNthId(idx + 1), typ)
+      }
+
+      Struct(name, fields)
+    }
+
+    // Indexes start from 1, not 0!
+    def getNthId(n: Int) = Id("_" + n)
+  }
+
+  object Array {
+    def apply(base: Type) = {
+      val name   = Id("__leon_array_" + base + "_t")
+      val data   = Var(dataId, Const(Pointer(base)))
+      val length = Var(lengthId, Const(Int32))
+      val fields = data :: length :: Nil
+
+      Struct(name, fields)
+    }
+
+    def lengthId = Id("length")
+    def dataId   = Id("data")
+  }
+
+
+  /* ---------------------------------------------------- Introspection ----- */
+  implicit class IntrospectionOps(val stmt: Stmt) {
+    def isLiteral = stmt match {
+      case _: IntLiteral  => true
+      case _: BoolLiteral => true
+      case _              => false
+    }
+
+    // True if statement can be used as a value
+    def isValue = isLiteral || {
+      stmt match {
+        //case _: Assign => true it's probably the case but for now let's ignore it
+        case c: Compound            => c.stmts.size == 1
+        case _: UnOp                => true
+        case _: MultiOp             => true
+        case _: SubscriptOp         => true
+        case _: AccessVar           => true
+        case _: AccessRef           => true
+        case _: AccessAddr          => true
+        case _: AccessField         => true
+        case _: Call                => true
+        case _: StructInit          => true
+        case _: ArrayInit           => true
+        case _: ArrayInitWithValues => true
+        case _                      => false
+      }
+    }
+
+    def isPure: Boolean = isLiteral || {
+      stmt match {
+        case NoStmt                 => true
+        case Compound(stmts)        => stmts forall { _.isPure }
+        case Assert(pred, _)        => pred.isPure
+        case UnOp(_, rhs)           => rhs.isPure
+        case MultiOp(_, stmts)      => Compound(stmts).isPure
+        case SubscriptOp(ptr, idx)  => (ptr ~ idx).isPure
+        case IfElse(c, t, e)        => (c ~ t ~ e).isPure
+        case While(c, b)            => (c ~ b).isPure
+        case AccessVar(_)           => true
+        case AccessRef(_)           => true
+        case AccessAddr(_)          => true
+        case AccessField(s, _)      => s.isPure
+        // case Call(id, args)      => true if args are pure and function `id` is pure too
+        case _                      => false
+      }
+    }
+
+    def isPureValue = isValue && isPure
+  }
+
+
+  /* ------------------------------------------------------------- DSL  ----- */
+  // Operator ~~ appends and flattens nested compounds
+  implicit class StmtOps(val stmt: Stmt) {
+    def ~(other: Stmt) = (stmt, other) match {
+      case (Compound(stmts), Compound(others)) => Compound(stmts ++ others)
+      case (stmt           , Compound(others)) => Compound(stmt  +: others)
+      case (Compound(stmts), other           ) => Compound(stmts :+ other )
+      case (stmt           , other           ) => Compound(stmt :: other :: Nil)
+    }
+
+    def ~~(others: Seq[Stmt]) = stmt ~ Compound(others)
+  }
+
+  implicit class StmtsOps(val stmts: Seq[Stmt]) {
+    def ~~(other: Stmt) = other match {
+      case Compound(others) => Compound(stmts) ~~ others
+      case other            => Compound(stmts) ~ other
+    }
+
+    def ~~~(others: Seq[Stmt]) = Compound(stmts) ~~ others
+  }
+
+  val True = BoolLiteral(true)
+  val False = BoolLiteral(false)
+
+
+  /* ------------------------------------------------ Fresh Generators  ----- */
+  object FreshId {
+    private var counter = -1
+    private val leonPrefix = "__leon_"
+
+    def apply(prefix: String = ""): Id = {
+      counter += 1
+      Id(leonPrefix + prefix + counter)
+    }
+  }
+
+  object FreshVar {
+    def apply(typ: Type, prefix: String = "") = Var(FreshId(prefix), typ)
+  }
+
+  object FreshVal {
+    def apply(typ: Type, prefix: String = "") = Val(FreshId(prefix), typ)
+  }
+}
+

--- a/src/main/scala/leon/genc/CAST.scala
+++ b/src/main/scala/leon/genc/CAST.scala
@@ -164,8 +164,8 @@ object CAST { // C Abstract Syntax Tree
   object Array {
     def apply(base: Type) = {
       val name   = Id("__leon_array_" + base + "_t")
-      val data   = Var(dataId, Const(Pointer(base)))
-      val length = Var(lengthId, Const(Int32))
+      val data   = Var(dataId, Pointer(base))
+      val length = Var(lengthId, Int32)
       val fields = data :: length :: Nil
 
       Struct(name, fields)

--- a/src/main/scala/leon/genc/CAST.scala
+++ b/src/main/scala/leon/genc/CAST.scala
@@ -52,9 +52,7 @@ object CAST { // C Abstract Syntax Tree
       else name
   }
 
-  case class Var(id: Id, typ: Type) extends Def {
-    def access = AccessVar(id)
-  }
+  case class Var(id: Id, typ: Type) extends Def
 
   /* ----------------------------------------------------------- Stmts  ----- */
   abstract class Stmt extends Tree

--- a/src/main/scala/leon/genc/CConverter.scala
+++ b/src/main/scala/leon/genc/CConverter.scala
@@ -233,8 +233,8 @@ class CConverter(val ctx: LeonContext, val prog: Program) {
     case Let(b, v, r)    => buildLet(b, v, r, false)
     case LetVar(b, v, r) => buildLet(b, v, r, true)
 
-    case LetDef(fd, rest) =>
-      convertToFun(fd) // The function get registered there
+    case LetDef(fds, rest) =>
+      fds foreach convertToFun // The functions get registered there
       convertToStmt(rest)
 
     case Assignment(varId, expr) =>

--- a/src/main/scala/leon/genc/CConverter.scala
+++ b/src/main/scala/leon/genc/CConverter.scala
@@ -402,8 +402,9 @@ class CConverter(val ctx: LeonContext, val prog: Program) {
     case BVLShiftRight(lhs, rhs)  => fatalError("operator >>> not supported")
 
     // Ignore assertions for now
-    case Ensuring(body, _) => convert(body)
-    case Require(_, body)  => convert(body)
+    case Ensuring(body, _)  => convert(body)
+    case Require(_, body)   => convert(body)
+    case Assert(_, _, body) => convert(body)
 
     case IfExpr(cond1, thn1, elze1) =>
       val condF = convertAndFlatten(cond1)

--- a/src/main/scala/leon/genc/CConverter.scala
+++ b/src/main/scala/leon/genc/CConverter.scala
@@ -413,8 +413,8 @@ class CConverter(val ctx: LeonContext, val prog: Program) {
         // Transform while (cond) { body } into
         // while (true) { if (cond) { body } else { break } }
         val condF = flatten(cond)
-        val ifelse  = condF.body ~~ buildIfElse(condF.value, body, CAST.Break)
-        CAST.While(CAST.True, ifelse)
+        val ifelse  = condF.body ~~ buildIfElse(condF.value, CAST.NoStmt, CAST.Break)
+        CAST.While(CAST.True, ifelse ~ body)
       }
 
     case FunctionInvocation(tfd @ TypedFunDef(fd, _), stdArgs) =>

--- a/src/main/scala/leon/genc/CConverter.scala
+++ b/src/main/scala/leon/genc/CConverter.scala
@@ -368,8 +368,8 @@ class CConverter(val ctx: LeonContext, val prog: Program) {
     case BVOr(lhs, rhs)           => buildBinOp(lhs, "|",   rhs)
     case BVXOr(lhs, rhs)          => buildBinOp(lhs, "^",   rhs)
     case BVShiftLeft(lhs, rhs)    => buildBinOp(lhs, "<<",  rhs)
-    case BVAShiftRight(lhs, rhs)  => buildBinOp(lhs, ">>>", rhs)
-    case BVLShiftRight(lhs, rhs)  => buildBinOp(lhs, ">>",  rhs)
+    case BVAShiftRight(lhs, rhs)  => buildBinOp(lhs, ">>", rhs)
+    case BVLShiftRight(lhs, rhs)  => fatalError("operator >>> not supported")
 
     // Ignore assertions for now
     case Ensuring(body, _) => convert(body)

--- a/src/main/scala/leon/genc/CConverter.scala
+++ b/src/main/scala/leon/genc/CConverter.scala
@@ -367,6 +367,15 @@ class CConverter(val ctx: LeonContext, val prog: Program) {
 
       argsFs.bodies ~~ CAST.StructInit(args, struct)
 
+    case CaseClassSelector(_, x1, fieldId) =>
+      val struct = convertToStruct(x1.getType)
+      val x2     = convertToStmt(x1)
+
+      val fs = normaliseExecution((x2, struct) :: Nil)
+      val x  = fs.values.head
+
+      fs.bodies ~~ CAST.AccessField(x, convertToId(fieldId))
+
     case LessThan(lhs, rhs)       => buildBinOp(lhs, "<",   rhs)
     case GreaterThan(lhs, rhs)    => buildBinOp(lhs, ">",   rhs)
     case LessEquals(lhs, rhs)     => buildBinOp(lhs, "<=",  rhs)

--- a/src/main/scala/leon/genc/CConverter.scala
+++ b/src/main/scala/leon/genc/CConverter.scala
@@ -666,7 +666,7 @@ class CConverter(val ctx: LeonContext, val prog: Program) {
         // Similarly to buildDeclInitVar:
         val (tmp, body) = f.value match {
           case CAST.IfElse(cond, thn, elze) =>
-            val tmp    = CAST.FreshVar(typ, "normexec")
+            val tmp    = CAST.FreshVar(typ.mutable, "normexec")
             val decl   = CAST.DeclVar(tmp)
             val ifelse = buildIfElse(cond, injectAssign(tmp, thn), injectAssign(tmp, elze))
             val body   = f.body ~~ decl ~ ifelse

--- a/src/main/scala/leon/genc/CConverter.scala
+++ b/src/main/scala/leon/genc/CConverter.scala
@@ -1,0 +1,644 @@
+/* Copyright 2009-2015 EPFL, Lausanne */
+
+package leon
+package genc
+
+import purescala.Common._
+import purescala.Definitions._
+import purescala.Expressions._
+import purescala.Types._
+import xlang.Expressions._
+
+import scala.reflect.ClassTag
+
+// don't import CAST._ to decrease possible confusion between the two ASTs
+
+class CConverter(val ctx: LeonContext, val prog: Program) {
+  def convert: CAST.Prog = convertToProg(prog)
+
+  // Global data: keep track of the custom types and function of the input program
+  // Using sequences and not sets to keep track of order/dependencies
+  private var typeDecls = Seq[CAST.Struct]()
+  private var functions = Seq[CAST.Fun]()
+
+  // Extra information about inner functions' context
+  // See classes VarInfo and FunCtx and functions convertToFun and
+  // FunctionInvocation conversion
+  private var funExtraArgss = Map[CAST.Id, Seq[CAST.Id]]()
+  private val emptyFunCtx   = FunCtx(Seq())
+
+  private def registerType(typ: CAST.Struct) {
+    // Types might be processed more than once as the corresponding CAST type
+    // is not cached and need to be reconstructed several time if necessary
+    if (!typeDecls.contains(typ)) {
+      typeDecls = typeDecls :+ typ
+      debug(s"New type registered: $typ")
+    }
+  }
+
+  private def registerFun(fun: CAST.Fun) {
+    // Unlike types, functions should not get defined multiple times as this
+    // would imply invalidating funExtraArgss
+    if (functions contains fun)
+      internalError("Function ${fun.id} defined more than once")
+    else
+      functions = functions :+ fun
+  }
+
+  // Register extra function argument for the function named `id`
+  private def registerFunExtraArgs(id: CAST.Id, params: Seq[CAST.Id]) {
+    funExtraArgss = funExtraArgss + ((id, params))
+  }
+
+  // Get the extra argument identifiers for the function named `id`
+  private def getFunExtraArgs(id: CAST.Id) = funExtraArgss.getOrElse(id, Seq())
+
+  // Apply the conversion function and make sure the resulting AST matches our expectation
+  private def convertTo[T](tree: Tree)(implicit funCtx: FunCtx, ct: ClassTag[T]): T = convert(tree) match {
+    case t: T => t
+    case x    => internalError(s"Expected an instance of $ct when converting $tree but got $x")
+  }
+
+  // Generic conversion function
+  // Currently simple aliases in case we need later to have special treatment instead
+  private def convertToType  (tree: Tree)(implicit funCtx: FunCtx) = convertTo[CAST.Type](tree)
+  private def convertToStruct(tree: Tree)(implicit funCtx: FunCtx) = convertTo[CAST.Struct](tree)
+  private def convertToId    (tree: Tree)(implicit funCtx: FunCtx) = convertTo[CAST.Id](tree)
+  private def convertToStmt  (tree: Tree)(implicit funCtx: FunCtx) = convertTo[CAST.Stmt](tree)
+  private def convertToVar   (tree: Tree)(implicit funCtx: FunCtx) = convertTo[CAST.Var](tree)
+
+  private def convertToProg(prog: Program): CAST.Prog = {
+    // Only process the main unit
+    val (mainUnits, _) = prog.units partition { _.isMainUnit }
+
+    if (mainUnits.size == 0) fatalError("No main unit in the program")
+    if (mainUnits.size >= 2) fatalError("Multiple main units in the program")
+
+    val mainUnit = mainUnits.head
+
+    debug(s"Converting the main unit:\n$mainUnit")
+    collectSymbols(mainUnit)
+
+    CAST.Prog(typeDecls, functions)
+  }
+
+  // Look for function and structure definitions
+  private def collectSymbols(unit: UnitDef) {
+    implicit val defaultFunCtx = emptyFunCtx
+
+    unit.defs.foreach {
+      case ModuleDef(_, funDefs, _) =>
+        funDefs.foreach {
+          case fd: FunDef       => convertToFun(fd)    // the function gets registered here
+          case cc: CaseClassDef => convertToStruct(cc) // the type declaration gets registered here
+
+          case x => internalError(s"Unknown function definition $x: ${x.getClass}")
+        }
+
+      case x => internalError(s"Unexpected definition $x instead of a ModuleDef")
+    }
+  }
+
+  // A variable can be locally declared (e.g. function parameter or local variable)
+  // or it can be "inherited" from a more global context (e.g. inner functions have
+  // access to their outer function parameters).
+  private case class VarInfo(x: CAST.Var, local: Boolean) {
+    // Transform a local variable into a global variable
+    def lift = VarInfo(x, false)
+
+    // Generate CAST variable declaration for function signature
+    def toParam = CAST.Var(x.id, CAST.Pointer(x.typ))
+
+    // Generate CAST access statement
+    def toArg = if (local) CAST.AccessAddr(x.id) else CAST.AccessVar(x.id)
+  }
+
+  private case class FunCtx(vars: Seq[VarInfo]) {
+    // Transform local variables into "outer" variables
+    def lift = FunCtx(vars map { _.lift })
+
+    // Create a new context with more local variables
+    def extend(x: CAST.Var): FunCtx = extend(Seq(x))
+    def extend(xs: Seq[CAST.Var]): FunCtx = {
+      val newVars = xs map { VarInfo(_, true) }
+      FunCtx(vars ++ newVars)
+    }
+
+    // Check if a given variable's identifier exists in the context and is an "outer" variable
+    def hasOuterVar(id: CAST.Id) = vars exists { vi => !vi.local && vi.x.id == id }
+
+    // List all variables' ids
+    def extractIds = vars map { _.x.id }
+
+    // Generate arguments for the given identifiers according to the current context
+    def toArgs(ids: Seq[CAST.Id]) = {
+      val filtered = vars filter { ids contains _.x.id }
+      filtered map { _.toArg }
+    }
+
+    // Generate parameters (var + type)
+    def toParams = vars map { _.toParam }
+  }
+
+  // Extract inner functions too
+  private def convertToFun(fd: FunDef)(implicit funCtx: FunCtx) = {
+    // Forbid return of array as they are allocated on the stack
+    if (containsArrayType(fd.returnType)) {
+      fatalError("Returning arrays is currently not allowed")
+    }
+
+    val id        = convertToId(fd.id)
+    val retType   = convertToType(fd.returnType)
+    val stdParams = fd.params map convertToVar
+
+    // Prepend existing variables from the outer function context to
+    // this function's parameters
+    val extraParams = funCtx.toParams
+    val params      = extraParams ++ stdParams
+
+    // Function Context:
+    // 1) Save the variables of the current context for later function invocation
+    // 2) Lift & augment funCtx with the current function's arguments
+    // 3) Propagate it to the current function's body
+
+    registerFunExtraArgs(id, funCtx.extractIds)
+
+    val funCtx2 = funCtx.lift.extend(stdParams)
+
+    val b    = convertToStmt(fd.fullBody)(funCtx2)
+    val body = retType match {
+      case CAST.Void => b
+      case _         => injectReturn(b)
+    }
+
+    val fun = CAST.Fun(id, retType, params, body)
+    registerFun(fun)
+
+    fun
+  }
+
+  private def convert(tree: Tree)(implicit funCtx: FunCtx): CAST.Tree = tree match {
+    /* ---------------------------------------------------------- Types ----- */
+    case Int32Type   => CAST.Int32
+    case BooleanType => CAST.Bool
+    case UnitType    => CAST.Void
+
+    case ArrayType(base) =>
+      val typ = CAST.Array(convertToType(base))
+      registerType(typ)
+      typ
+
+    case TupleType(bases) =>
+      val typ = CAST.Tuple(bases map convertToType)
+      registerType(typ)
+      typ
+
+    case cd: CaseClassDef =>
+      if (cd.isAbstract)         fatalError("Abstract types are not supported")
+      if (cd.hasParent)          fatalError("Inheritance is not supported")
+      if (cd.isCaseObject)       fatalError("Case Objects are not supported")
+      if (cd.tparams.length > 0) fatalError("Type Parameters are not supported")
+      if (cd.methods.length > 0) fatalError("Methods are not yet supported")
+
+      val id     = convertToId(cd.id)
+      val fields = cd.fields map convertToVar
+      val typ    = CAST.Struct(id, fields)
+
+      registerType(typ)
+      typ
+
+    case CaseClassType(cd, _) => convertToStruct(cd) // reuse `case CaseClassDef`
+
+    /* ------------------------------------------------------- Literals ----- */
+    case IntLiteral(v)     => CAST.IntLiteral(v)
+    case BooleanLiteral(b) => CAST.BoolLiteral(b)
+    case UnitLiteral()     => CAST.NoStmt
+
+    /* ------------------------------------ Definitions and Statements  ----- */
+    case id: Identifier =>
+      if (id.name == "main") CAST.Id("main") // and not `main0`
+      else                   CAST.Id(id.uniqueName)
+
+    // Function parameter
+    case vd: ValDef  => buildVal(vd.id, vd.getType)
+
+    // Accessing variable
+    case v: Variable => buildAccessVar(v.id)
+
+    case Block(exprs, last) =>
+      // Interleave the "bodies" of flatten expressions and their values
+      // and generate a Compound statement
+      (exprs :+ last) map convertToStmt reduce { _ ~ _ }
+
+    case Let(b, v, r)    => buildLet(b, v, r, false)
+    case LetVar(b, v, r) => buildLet(b, v, r, true)
+
+    case LetDef(fd, rest) =>
+      convertToFun(fd) // The function get registered there
+      convertToStmt(rest)
+
+    case Assignment(varId, expr) =>
+      val f = convertAndFlatten(expr)
+      val x = buildAccessVar(varId)
+
+      val assign = CAST.Assign(x, f.value)
+
+      f.body ~~ assign
+
+    case t @ Tuple(exprs) =>
+      val struct = convertToStruct(t.getType)
+      val types  = struct.fields map { _.typ }
+      val fs     = convertAndNormaliseExecution(exprs, types)
+      val args   = fs.values.zipWithIndex map {
+        case (arg, idx) => (CAST.Tuple.getNthId(idx + 1), arg)
+      }
+
+      fs.bodies ~~ CAST.StructInit(args, struct)
+
+    case TupleSelect(tuple, idx) => // here idx is already 1-based
+      CAST.AccessField(convertToStmt(tuple), CAST.Tuple.getNthId(idx))
+
+    case ArrayLength(array) =>
+      CAST.AccessField(convertToStmt(array), CAST.Array.lengthId)
+
+    case ArraySelect(array1, index) =>
+      val arrayF = convertAndFlatten(array1)
+      val idxF   = convertAndFlatten(index)
+      val ptr    = CAST.AccessField(arrayF.value, CAST.Array.dataId)
+
+      val select = if (idxF.value.isValue) {
+        CAST.SubscriptOp(ptr, idxF.value)
+      } else {
+        val tmp  = CAST.FreshVar(CAST.Int32, "index")
+        val decl = CAST.DeclVar(tmp)
+        val set  = injectAssign(tmp, idxF.value)
+
+        decl ~ set ~ CAST.SubscriptOp(ptr, CAST.AccessVar(tmp.id))
+      }
+
+      arrayF.body ~~~ idxF.body ~ select
+
+    case NonemptyArray(elems, Some((defaultValue, length))) if elems.isEmpty =>
+      val lengthF = convertAndFlatten(length)
+      val typ     = convertToType(defaultValue.getType)
+      val valueF  = convertAndFlatten(defaultValue)
+      // TODO the value (which can be a function call) should be saved into
+      // a local variable to prevent calling it many times
+
+      lengthF.body ~~~ valueF.body ~ CAST.ArrayInit(lengthF.value, typ, valueF.value)
+
+    case NonemptyArray(elems, Some(_)) =>
+      fatalError("NonemptyArray with non empty elements is not supported")
+
+    case NonemptyArray(elems, None) => // Here elems is non-empty
+      // Sort values according the the key (aka index)
+      val indexes = elems.keySet.toSeq.sorted
+      val values  = indexes map { elems(_) }
+
+      // Assert all types are the same
+      val types   = values map { e => convertToType(e.getType) }
+      val typ     = types(0)
+      val allSame = types forall { _ == typ }
+      if (!allSame) fatalError("Heterogenous arrays are not supported")
+
+      val fs = convertAndNormaliseExecution(values, types)
+
+      fs.bodies ~~ CAST.ArrayInitWithValues(typ, fs.values)
+
+    case ArrayUpdate(array, index, newValue) =>
+      val lhsF = convertAndFlatten(ArraySelect(array, index))
+      val rhsF = convertAndFlatten(newValue)
+
+      lhsF.body ~~~ rhsF.body ~ CAST.Assign(lhsF.value, rhsF.value)
+
+    case CaseClass(typ, args1) =>
+      val struct    = convertToStruct(typ)
+      val types     = struct.fields map { _.typ }
+      val argsFs    = convertAndNormaliseExecution(args1, types)
+      val fieldsIds = typ.classDef.fieldsIds map convertToId
+      val args      = fieldsIds zip argsFs.values
+
+      argsFs.bodies ~~ CAST.StructInit(args, struct)
+
+    case LessThan(lhs, rhs)       => buildBinOp(lhs, "<",   rhs)
+    case GreaterThan(lhs, rhs)    => buildBinOp(lhs, ">",   rhs)
+    case LessEquals(lhs, rhs)     => buildBinOp(lhs, "<=",  rhs)
+    case GreaterEquals(lhs, rhs)  => buildBinOp(lhs, ">=",  rhs)
+    case Equals(lhs, rhs)         => buildBinOp(lhs, "==",  rhs)
+
+    case Not(rhs)                 => buildUnOp (     "!",   rhs)
+
+    case And(exprs)               => buildMultiOp("&&", exprs)
+    case Or(exprs)                => buildMultiOp("||", exprs)
+
+    case BVPlus(lhs, rhs)         => buildBinOp(lhs, "+",   rhs)
+    case BVMinus(lhs, rhs)        => buildBinOp(lhs, "-",   rhs)
+    case BVUMinus(rhs)            => buildUnOp (     "-",   rhs)
+    case BVTimes(lhs, rhs)        => buildBinOp(lhs, "*",   rhs)
+    case BVDivision(lhs, rhs)     => buildBinOp(lhs, "/",   rhs)
+    case BVRemainder(lhs, rhs)    => buildBinOp(lhs, "%",   rhs)
+    case BVNot(rhs)               => buildUnOp (     "!",   rhs) // TODO check if this one isn't in fact '~'
+    case BVAnd(lhs, rhs)          => buildBinOp(lhs, "&",   rhs)
+    case BVOr(lhs, rhs)           => buildBinOp(lhs, "|",   rhs)
+    case BVXOr(lhs, rhs)          => buildBinOp(lhs, "^",   rhs)
+    case BVShiftLeft(lhs, rhs)    => buildBinOp(lhs, "<<",  rhs)
+    case BVAShiftRight(lhs, rhs)  => buildBinOp(lhs, ">>>", rhs)
+    case BVLShiftRight(lhs, rhs)  => buildBinOp(lhs, ">>",  rhs)
+
+    // Ignore assertions for now
+    case Ensuring(body, _) => convert(body)
+    case Require(_, body)  => convert(body)
+
+    case IfExpr(cond1, thn1, elze1) =>
+      val condF = convertAndFlatten(cond1)
+      val thn   = convertToStmt(thn1)
+      val elze  = convertToStmt(elze1)
+
+      condF.body ~~ buildIfElse(condF.value, thn, elze)
+
+    case While(cond1, body1) =>
+      val cond = convertToStmt(cond1)
+      val body = convertToStmt(body1)
+
+      if (cond.isPureValue) {
+        CAST.While(cond, body)
+      } else {
+        // Transform while (cond) { body } into
+        // while (true) { if (cond) { body } else { break } }
+        val condF = flatten(cond)
+        val ifelse  = condF.body ~~ buildIfElse(condF.value, body, CAST.Break)
+        CAST.While(CAST.True, ifelse)
+      }
+
+    case FunctionInvocation(tfd @ TypedFunDef(fd, _), stdArgs) =>
+      // In addition to regular function parameters, add the callee's extra parameters
+      val id        = convertToId(fd.id)
+      val types     = tfd.params map { p => convertToType(p.getType) }
+      val fs        = convertAndNormaliseExecution(stdArgs, types)
+      val extraArgs = funCtx.toArgs(getFunExtraArgs(id))
+      val args      = extraArgs ++ fs.values
+
+      fs.bodies ~~ CAST.Call(id, args)
+
+    case unsupported =>
+      fatalError(s"$unsupported (of type ${unsupported.getClass}) is currently not supported by GenC")
+  }
+
+  private def buildVar(id: Identifier, typ: TypeTree)(implicit funCtx: FunCtx) =
+    CAST.Var(convertToId(id), convertToType(typ))
+
+  private def buildVal(id: Identifier, typ: TypeTree)(implicit funCtx: FunCtx) =
+    CAST.Val(convertToId(id), convertToType(typ))
+
+  private def buildAccessVar(id1: Identifier)(implicit funCtx: FunCtx) = {
+    // Depending on the context, we have to deference the variable
+    val id = convertToId(id1)
+    if (funCtx.hasOuterVar(id)) CAST.AccessRef(id)
+    else                        CAST.AccessVar(id)
+  }
+
+  private def buildLet(id: Identifier, value: Expr, rest1: Expr, forceVar: Boolean)
+                      (implicit funCtx: FunCtx): CAST.Stmt = {
+    val (x, stmt) = buildDeclInitVar(id, value, forceVar)
+
+    // Augment ctx for the following instructions
+    val funCtx2 = funCtx.extend(x)
+    val rest    = convertToStmt(rest1)(funCtx2)
+
+    stmt ~ rest
+  }
+
+
+  // Create a new variable for the given value, potentially immutable, and initialize it
+  private def buildDeclInitVar(id: Identifier, v: Expr, forceVar: Boolean)
+                              (implicit funCtx: FunCtx): (CAST.Var, CAST.Stmt) = {
+    val valueF = convertAndFlatten(v)
+    val typ    = v.getType
+
+    valueF.value match {
+      case CAST.IfElse(cond, thn, elze) =>
+        val x      = buildVar(id, typ)
+        val decl   = CAST.DeclVar(x)
+        val ifelse = buildIfElse(cond, injectAssign(x, thn), injectAssign(x, elze))
+        val init   = decl ~ ifelse
+
+        (x, valueF.body ~~ init)
+
+      case value =>
+        val x    = if (forceVar) buildVar(id, typ) else buildVal(id, typ)
+        val init = CAST.DeclInitVar(x, value)
+
+        (x, valueF.body ~~ init)
+    }
+  }
+
+  private def buildBinOp(lhs: Expr, op: String, rhs: Expr)(implicit funCtx: FunCtx) = {
+    buildMultiOp(op, lhs :: rhs :: Nil)
+  }
+
+  private def buildUnOp(op: String, rhs1: Expr)(implicit funCtx: FunCtx) = {
+    val rhsF = convertAndFlatten(rhs1)
+    rhsF.body ~~ CAST.Op(op, rhsF.value)
+  }
+
+  private def buildMultiOp(op: String, exprs: Seq[Expr])(implicit funCtx: FunCtx): CAST.Stmt = {
+    require(exprs.length >= 2)
+
+    val stmts = exprs map convertToStmt
+    val types = exprs map { e => convertToType(e.getType) }
+
+    buildMultiOp(op, stmts, types)
+  }
+
+  private def buildMultiOp(op: String, stmts: Seq[CAST.Stmt], types: Seq[CAST.Type]): CAST.Stmt = {
+      // Default operator constuction when either pure statements are involved
+      // or no shortcut can happen
+      def defaultBuild = {
+        val fs = normaliseExecution(stmts, types)
+        fs.bodies ~~ CAST.Op(op, fs.values)
+      }
+
+      if (stmts forall { _.isPureValue }) defaultBuild
+      else op match {
+      case "&&" =>
+        // Apply short-circuit if needed
+        if (stmts.length == 2) {
+          // Base case:
+          // { { a; v } && { b; w } }
+          // is mapped onto
+          // { a; if (v) { b; w } else { false } }
+          val av = flatten(stmts(0))
+          val bw = stmts(1)
+
+          if (bw.isPureValue) defaultBuild
+          else av.body ~~ buildIfElse(av.value, bw, CAST.False)
+        } else {
+          // Recursive case:
+          // { { a; v } && ... }
+          // is mapped onto
+          // { a; if (v) { ... } else { false } }
+          val av = flatten(stmts(0))
+          val rest = buildMultiOp(op, stmts.tail, types.tail)
+
+          if (rest.isPureValue) defaultBuild
+          else av.body ~~ buildIfElse(av.value, rest, CAST.False)
+        }
+
+      case "||" =>
+        // Apply short-circuit if needed
+        if (stmts.length == 2) {
+          // Base case:
+          // { { a; v } || { b; w } }
+          // is mapped onto
+          // { a; if (v) { true } else { b; w } }
+          val av = flatten(stmts(0))
+          val bw = stmts(1)
+
+          if (bw.isPureValue) defaultBuild
+          else av.body ~~ buildIfElse(av.value, CAST.True, bw)
+        } else {
+          // Recusrive case:
+          // { { a; v } || ... }
+          // is mapped onto
+          // { a; if (v) { true } else { ... } }
+          val av = flatten(stmts(0))
+          val rest = buildMultiOp(op, stmts.tail, types.tail)
+
+          if (rest.isPureValue) defaultBuild
+          else av.body ~~ buildIfElse(av.value, CAST.True, rest)
+        }
+
+      case _ =>
+        defaultBuild
+    }
+  }
+
+  // Flatten `if (if (cond1) thn1 else elze1) thn2 else elze2`
+  // into `if (cond1) { if (thn1) thn2 else elz2 } else { if (elz1) thn2 else elze2 }`
+  // or, if possible, into `if ((cond1 && thn1) || elz1) thn2 else elz2`
+  //
+  // Flatten `if (true) thn else elze` into `thn`
+  // Flatten `if (false) thn else elze` into `elze`
+  private def buildIfElse(cond: CAST.Stmt, thn2: CAST.Stmt, elze2: CAST.Stmt): CAST.Stmt = {
+    val condF = flatten(cond)
+
+    val ifelse = condF.value match {
+      case CAST.IfElse(cond1, thn1, elze1) =>
+        if (cond1.isPure && thn1.isPure && elze1.isPure) {
+          val bools = CAST.Bool :: CAST.Bool :: Nil
+          val ands  = cond1 :: thn1 :: Nil
+          val ors   = buildMultiOp("&&", ands, bools) :: elze1 :: Nil
+          val condX = buildMultiOp("||", ors, bools)
+          CAST.IfElse(condX, thn2, elze2)
+        } else {
+          buildIfElse(cond1, buildIfElse(thn1, thn2, elze2), buildIfElse(elze1, thn2, elze2))
+        }
+
+      case CAST.True  => thn2
+      case CAST.False => elze2
+      case cond2      => CAST.IfElse(cond2, thn2, elze2)
+    }
+
+    condF.body ~~ ifelse
+  }
+
+  private def injectReturn(stmt: CAST.Stmt): CAST.Stmt = {
+    val f = flatten(stmt)
+
+    f.value match {
+      case CAST.IfElse(cond, thn, elze) =>
+        f.body ~~ CAST.IfElse(cond, injectReturn(thn), injectReturn(elze))
+
+      case _ =>
+        f.body ~~ CAST.Return(f.value)
+    }
+  }
+
+  private def injectAssign(x: CAST.Var, stmt: CAST.Stmt): CAST.Stmt = {
+    val f = flatten(stmt)
+
+    f.value match {
+      case CAST.IfElse(cond, thn, elze) =>
+        f.body ~~ CAST.IfElse(cond, injectAssign(x, thn), injectAssign(x, elze))
+
+      case _ =>
+        f.body ~~ CAST.Assign(x.access, f.value)
+    }
+  }
+
+  // Flattened represents a non-empty statement { a; b; ...; y; z }
+  // split into body { a; b; ...; y } and value z
+  private case class Flattened(value: CAST.Stmt, body: Seq[CAST.Stmt])
+
+  // FlattenedSeq does the same as Flattened for a sequence of non-empty statements
+  private case class FlattenedSeq(values: Seq[CAST.Stmt], bodies: Seq[CAST.Stmt])
+
+  private def flatten(stmt: CAST.Stmt) = stmt match {
+    case CAST.Compound(stmts) if stmts.isEmpty => internalError(s"Empty compound cannot be flattened")
+    case CAST.Compound(stmts)                  => Flattened(stmts.last, stmts.init)
+    case stmt                                  => Flattened(stmt, Seq())
+  }
+
+  private def convertAndFlatten(expr: Expr)(implicit funCtx: FunCtx) = flatten(convertToStmt(expr))
+
+  // Normalise execution order of, for example, function parameters;
+  // `types` represents the expected type of the corresponding values
+  // in case an intermediary variable needs to be created
+  private def convertAndNormaliseExecution(exprs: Seq[Expr], types: Seq[CAST.Type])
+                                          (implicit funCtx: FunCtx) = {
+    require(exprs.length == types.length)
+    normaliseExecution(exprs map convertToStmt, types)
+  }
+
+  private def normaliseExecution(stmts: Seq[CAST.Stmt], types: Seq[CAST.Type]) = {
+    require(stmts.length == types.length)
+
+    // Create temporary variables if needed
+    val stmtsFs = stmts map flatten
+    val fs = (stmtsFs zip types) map {
+      case (f, _) if f.value.isPureValue => f
+
+      case (f, typ) =>
+        // Similarly to buildDeclInitVar:
+        val (tmp, body) = f.value match {
+          case CAST.IfElse(cond, thn, elze) =>
+            val tmp    = CAST.FreshVar(typ, "normexec")
+            val decl   = CAST.DeclVar(tmp)
+            val ifelse = buildIfElse(cond, injectAssign(tmp, thn), injectAssign(tmp, elze))
+            val body   = f.body ~~ decl ~ ifelse
+
+            (tmp, body)
+
+          case value =>
+            val tmp  = CAST.FreshVal(typ, "normexec")
+            val body = f.body ~~ CAST.DeclInitVar(tmp, f.value)
+
+            (tmp, body)
+        }
+
+        val value = CAST.AccessVar(tmp.id)
+        flatten(body ~ value)
+    }
+
+    val empty  = Seq[CAST.Stmt]()
+    val bodies = fs.foldLeft(empty){ _ ++ _.body }
+    val values = fs map { _.value }
+
+    FlattenedSeq(values, bodies)
+  }
+
+  private def containsArrayType(typ: TypeTree): Boolean = typ match {
+    case Int32Type            => false
+    case BooleanType          => false
+    case UnitType             => false
+    case ArrayType(_)         => true
+    case TupleType(bases)     => bases exists containsArrayType
+    case CaseClassType(cd, _) => cd.fields map { _.getType } exists containsArrayType
+  }
+
+  private def internalError(msg: String) = ctx.reporter.internalError(msg)
+  private def fatalError(msg: String)    = ctx.reporter.fatalError(msg)
+  private def debug(msg: String)         = ctx.reporter.debug(msg)(utils.DebugSectionGenC)
+
+}
+

--- a/src/main/scala/leon/genc/CConverter.scala
+++ b/src/main/scala/leon/genc/CConverter.scala
@@ -337,7 +337,7 @@ class CConverter(val ctx: LeonContext, val prog: Program) {
     case BVTimes(lhs, rhs)        => buildBinOp(lhs, "*",   rhs)
     case BVDivision(lhs, rhs)     => buildBinOp(lhs, "/",   rhs)
     case BVRemainder(lhs, rhs)    => buildBinOp(lhs, "%",   rhs)
-    case BVNot(rhs)               => buildUnOp (     "!",   rhs) // TODO check if this one isn't in fact '~'
+    case BVNot(rhs)               => buildUnOp (     "~",   rhs)
     case BVAnd(lhs, rhs)          => buildBinOp(lhs, "&",   rhs)
     case BVOr(lhs, rhs)           => buildBinOp(lhs, "|",   rhs)
     case BVXOr(lhs, rhs)          => buildBinOp(lhs, "^",   rhs)

--- a/src/main/scala/leon/genc/CFileOutputPhase.scala
+++ b/src/main/scala/leon/genc/CFileOutputPhase.scala
@@ -1,0 +1,54 @@
+/* Copyright 2009-2015 EPFL, Lausanne */
+
+package leon
+package genc
+
+import java.io.File
+import java.io.FileWriter
+import java.io.BufferedWriter
+
+object CFileOutputPhase extends UnitPhase[CAST.Prog] {
+
+  val name = "C File Output"
+  val description = "Output converted C program to the specified file (default leon.c)"
+
+  val optOutputFile = new LeonOptionDef[String] {
+    val name = "o"
+    val description = "Output file"
+    val default = "leon.c"
+    val usageRhs = "file"
+    val parser = OptionParsers.stringParser
+  }
+
+  override val definedOptions: Set[LeonOptionDef[Any]] = Set(optOutputFile)
+
+  def apply(ctx: LeonContext, program: CAST.Prog) {
+    // Get the output file name from command line options, or use default
+    val outputFile = new File(ctx.findOptionOrDefault(optOutputFile))
+    val parent = outputFile.getParentFile()
+    try {
+      if (parent != null) {
+        parent.mkdirs()
+      }
+    } catch {
+      case _ : java.io.IOException => ctx.reporter.fatalError("Could not create directory " + parent)
+    }
+
+    // Output C code to the file
+    try {
+      val fstream = new FileWriter(outputFile)
+      val out = new BufferedWriter(fstream)
+
+      val p = new CPrinter
+      p.print(program)
+
+      out.write(p.toString)
+      out.close()
+
+      ctx.reporter.info(s"Output written to $outputFile")
+    } catch {
+      case _ : java.io.IOException => ctx.reporter.fatalError("Could not write on " + outputFile)
+    }
+  }
+
+}

--- a/src/main/scala/leon/genc/CPrinter.scala
+++ b/src/main/scala/leon/genc/CPrinter.scala
@@ -1,0 +1,200 @@
+/* Copyright 2009-2015 EPFL, Lausanne */
+
+package leon
+package genc
+
+import CAST._
+import CPrinterHelpers._
+
+class CPrinter(val sb: StringBuffer = new StringBuffer) {
+  override def toString = sb.toString
+
+  def print(tree: Tree) = pp(tree)(PrinterContext(0, this))
+
+  def pp(tree: Tree)(implicit ctx: PrinterContext): Unit = tree match {
+    /* ---------------------------------------------------------- Types ----- */
+    case typ: Type => c"${typ.toString}"
+
+
+    /* ------------------------------------------------------- Literals ----- */
+    case IntLiteral(v) => c"$v"
+    case BoolLiteral(b) => c"$b"
+
+
+    /* --------------------------------------------------- Definitions  ----- */
+    case Prog(structs, functions) =>
+      c"""|/* ------------------------------------ includes ----- */
+          |
+          |${nary(includeStmts, sep = "\n")}
+          |
+          |/* ---------------------- data type declarations ----- */
+          |
+          |${nary(structs map StructDecl, sep = "\n")}
+          |
+          |/* ----------------------- data type definitions ----- */
+          |
+          |${nary(structs map StructDef, sep = "\n")}
+          |
+          |/* ----------------------- function declarations ----- */
+          |
+          |${nary(functions map FunDecl, sep = "\n")}
+          |
+          |/* ------------------------ function definitions ----- */
+          |
+          |${nary(functions, sep = "\n")}
+          |"""
+
+    case f @ Fun(_, _, _, body) =>
+      c"""|${FunSign(f)}
+          |{
+          |  $body
+          |}
+          |"""
+
+    case Id(name) => c"$name"
+
+
+    /* --------------------------------------------------------- Stmts  ----- */
+    case NoStmt => c"/* empty */"
+
+
+    // Try to print new lines and semicolon somewhat correctly
+    case Compound(stmts) if stmts.isEmpty => // should not happen
+
+    case Compound(stmts) if stmts.length == 1 =>
+      stmts.head match {
+        case s: Call => c"$s;" // for function calls whose returned value is not saved
+        case s       => c"$s"
+      }
+
+    case Compound(stmts) =>
+      val head = stmts.head
+      val tail = Compound(stmts.tail)
+
+      head match {
+        case s: Call => c"$s;" // for function calls whose returned value is not saved
+        case s       => c"$s"
+      }
+      c"$NewLine$tail"
+
+    case Assert(pred, Some(error)) => c"assert($pred); /* $error */"
+    case Assert(pred, None)        => c"assert($pred);"
+
+    case Var(id, _) => c"$id"
+    case DeclVar(Var(id, typ)) => c"$typ $id;"
+
+    // TODO depending on the type of array (e.g. `char`) or the value (e.g. `0`), we could use `memset`.
+    case DeclInitVar(Var(id, typ), ai: ArrayInit) => // Note that `typ` is a struct here
+      val buffer = FreshId("vla_buffer")
+      val i = FreshId("i")
+      c"""|${ai.valueType} $buffer[${ai.length}];
+          |for (${Int32} $i = 0; $i < ${ai.length}; ++$i) {
+          |  $buffer[$i] = ${ai.defaultValue};
+          |}
+          |$typ $id = { .length = ${ai.length}, .data = $buffer };
+          |"""
+
+    case DeclInitVar(Var(id, typ), ai: ArrayInitWithValues) => // Note that `typ` is a struct here
+      val buffer = FreshId("vla_buffer")
+      c"$NewLine${ai.valueType} $buffer[${ai.length}];$NewLine"
+      for ((v, i) <- ai.values.zipWithIndex) {
+        c"$buffer[$i] = $v;$NewLine"
+      }
+      c"$typ $id = { .length = ${ai.length}, .data = $buffer };$NewLine"
+
+    case DeclInitVar(Var(id, typ), value) =>
+      c"$typ $id = $value;"
+
+    case Assign(lhs, rhs) =>
+      c"$lhs = $rhs;"
+
+    case UnOp(op, rhs) => c"($op $rhs)"
+    case MultiOp(op, stmts) => c"""${nary(stmts, sep = s" ${op.fixMargin} ")}"""
+    case SubscriptOp(ptr, idx) => c"$ptr[$idx]"
+
+    case Break => c"break;"
+    case Return(stmt) => c"return $stmt;"
+
+    case IfElse(cond, thn, elze) =>
+      c"""|if ($cond)
+          |{
+          |  $thn
+          |}
+          |else
+          |{
+          |  $elze
+          |}
+          |"""
+
+    case While(cond, body) =>
+      c"""|while ($cond)
+          |{
+          |  $body
+          |}
+          |"""
+
+    case AccessVar(id)              => c"$id"
+    case AccessRef(id)              => c"(*$id)"
+    case AccessAddr(id)             => c"(&$id)"
+    case AccessField(struct, field) => c"$struct.$field"
+    case Call(id, args)             => c"$id($args)"
+
+    case StructInit(args, struct) =>
+      c"(${struct.id}) { "
+      for ((id, stmt) <- args.init) {
+        c".$id = $stmt, "
+      }
+      if (!args.isEmpty) {
+        val (id, stmt) = args.last
+        c".$id = $stmt "
+      }
+      c"}"
+
+    /* --------------------------------------------------------- Error  ----- */
+    case tree => sys.error(s"CPrinter: <<$tree>> was not handled properly")
+  }
+
+
+  def pp(wt: WrapperTree)(implicit ctx: PrinterContext): Unit = wt match {
+    case FunDecl(f) =>
+      c"${FunSign(f)};$NewLine"
+
+    case FunSign(Fun(id, retType, Nil, _)) =>
+      c"""|$retType
+          |$id($Void)"""
+
+    case FunSign(Fun(id, retType, params, _)) =>
+      c"""|$retType
+          |$id(${nary(params map DeclParam)})"""
+
+    case DeclParam(Var(id, typ)) =>
+      c"$typ $id"
+
+    case StructDecl(s) =>
+      c"struct $s;"
+
+    case StructDef(Struct(name, fields)) =>
+      c"""|typedef struct $name {
+          |  ${nary(fields map DeclParam, sep = ";\n", closing = ";")}
+          |} $name;
+          |"""
+
+    case NewLine =>
+      c"""|
+          |"""
+  }
+
+  /** Hardcoded list of required include files from C standard library **/
+  lazy val includes = "assert.h" :: "stdbool.h" :: "stdint.h" :: Nil
+  lazy val includeStmts = includes map { i => s"#include <$i>" }
+
+  /** Wrappers to distinguish how the data should be printed **/
+  sealed abstract class WrapperTree
+  case class FunDecl(f: Fun) extends WrapperTree
+  case class FunSign(f: Fun) extends WrapperTree
+  case class DeclParam(x: Var) extends WrapperTree
+  case class StructDecl(s: Struct) extends WrapperTree
+  case class StructDef(s: Struct) extends WrapperTree
+  case object NewLine extends WrapperTree
+}
+

--- a/src/main/scala/leon/genc/CPrinter.scala
+++ b/src/main/scala/leon/genc/CPrinter.scala
@@ -105,8 +105,9 @@ class CPrinter(val sb: StringBuffer = new StringBuffer) {
     case Assign(lhs, rhs) =>
       c"$lhs = $rhs;"
 
-    case UnOp(op, rhs) => c"($op $rhs)"
-    case MultiOp(op, stmts) => c"""${nary(stmts, sep = s" ${op.fixMargin} ")}"""
+    case UnOp(op, rhs) => c"($op$rhs)"
+    case MultiOp(op, stmts) => c"""${nary(stmts, sep = s" ${op.fixMargin} ",
+                                          opening = "(", closing = ")")}"""
     case SubscriptOp(ptr, idx) => c"$ptr[$idx]"
 
     case Break => c"break;"

--- a/src/main/scala/leon/genc/CPrinter.scala
+++ b/src/main/scala/leon/genc/CPrinter.scala
@@ -57,25 +57,16 @@ class CPrinter(val sb: StringBuffer = new StringBuffer) {
     /* --------------------------------------------------------- Stmts  ----- */
     case NoStmt => c"/* empty */"
 
-
-    // Try to print new lines and semicolon somewhat correctly
-    case Compound(stmts) if stmts.isEmpty => // should not happen
-
-    case Compound(stmts) if stmts.length == 1 =>
-      stmts.head match {
-        case s: Call => c"$s;" // for function calls whose returned value is not saved
-        case s       => c"$s"
-      }
-
     case Compound(stmts) =>
-      val head = stmts.head
-      val tail = Compound(stmts.tail)
+      val lastIdx = stmts.length - 1
 
-      head match {
-        case s: Call => c"$s;" // for function calls whose returned value is not saved
-        case s       => c"$s"
+      for ((stmt, idx) <- stmts.zipWithIndex) {
+        if (stmt.isValue) c"$stmt;"
+        else              c"$stmt"
+
+        if (idx != lastIdx)
+          c"$NewLine"
       }
-      c"$NewLine$tail"
 
     case Assert(pred, Some(error)) => c"assert($pred); /* $error */"
     case Assert(pred, None)        => c"assert($pred);"

--- a/src/main/scala/leon/genc/CPrinterHelper.scala
+++ b/src/main/scala/leon/genc/CPrinterHelper.scala
@@ -1,0 +1,86 @@
+/* Copyright 2009-2015 EPFL, Lausanne */
+
+package leon
+package genc
+
+import CAST.Tree
+
+/* Printer helpers adapted to C code generation */
+
+case class PrinterContext(
+  indent: Int,
+  printer: CPrinter
+)
+
+object CPrinterHelpers {
+  implicit class Printable(val f: PrinterContext => Any) extends AnyVal {
+    def print(ctx: PrinterContext) = f(ctx)
+  }
+
+  implicit class PrinterHelper(val sc: StringContext) extends AnyVal {
+    def c(args: Any*)(implicit ctx: PrinterContext): Unit = {
+      val printer = ctx.printer
+      import printer.WrapperTree
+      val sb      = printer.sb
+
+      val strings     = sc.parts.iterator
+      val expressions = args.iterator
+
+      var extraInd = 0
+      var firstElem = true
+
+      while(strings.hasNext) {
+        val s = strings.next.stripMargin
+
+        // Compute indentation
+        val start = s.lastIndexOf('\n')
+        if(start >= 0 || firstElem) {
+          var i = start + 1
+          while(i < s.length && s(i) == ' ') {
+            i += 1
+          }
+          extraInd = (i - start - 1) / 2
+        }
+
+        firstElem = false
+
+        // Make sure new lines are also indented
+        sb.append(s.replaceAll("\n", "\n" + ("  " * ctx.indent)))
+
+        val nctx = ctx.copy(indent = ctx.indent + extraInd)
+
+        if (expressions.hasNext) {
+          val e = expressions.next
+
+          e match {
+            case ts: Seq[Any] =>
+              nary(ts).print(nctx)
+
+            case t: Tree =>
+              printer.pp(t)(nctx)
+
+            case wt: WrapperTree =>
+              printer.pp(wt)(nctx)
+
+            case p: Printable =>
+              p.print(nctx)
+
+            case e =>
+              sb.append(e.toString)
+          }
+        }
+      }
+    }
+  }
+
+  def nary(ls: Seq[Any], sep: String = ", ", opening: String = "", closing: String = ""): Printable = {
+    val (o, c) = if(ls.isEmpty) ("", "") else (opening, closing)
+    val strs = o +: List.fill(ls.size-1)(sep) :+ c
+
+    implicit pctx: PrinterContext =>
+      new StringContext(strs: _*).c(ls: _*)
+  }
+
+}
+
+

--- a/src/main/scala/leon/genc/GenerateCPhase.scala
+++ b/src/main/scala/leon/genc/GenerateCPhase.scala
@@ -1,0 +1,20 @@
+/* Copyright 2009-2015 EPFL, Lausanne */
+
+package leon
+package genc
+
+import purescala.Definitions.Program
+
+object GenerateCPhase extends SimpleLeonPhase[Program, CAST.Prog] {
+
+  val name = "Generate C"
+  val description = "Generate equivalent C code from Leon's AST"
+
+  def apply(ctx: LeonContext, program: Program) = {
+    ctx.reporter.debug("Running code conversion phase: " + name)(utils.DebugSectionLeon)
+    val cprogram = new CConverter(ctx, program).convert
+    cprogram
+  }
+
+}
+

--- a/src/main/scala/leon/purescala/Expressions.scala
+++ b/src/main/scala/leon/purescala/Expressions.scala
@@ -725,11 +725,11 @@ object Expressions {
   case class BVShiftLeft(lhs: Expr, rhs: Expr) extends Expr {
     val getType = Int32Type
   }
-  /** $encodingof `... >>> ...` $noteBitvector (logical shift) */
+  /** $encodingof `... >> ...` $noteBitvector (arithmetic shift, sign-preserving) */
   case class BVAShiftRight(lhs: Expr, rhs: Expr) extends Expr {
     val getType = Int32Type
   }
-  /** $encodingof `... >> ...` $noteBitvector (arithmetic shift, sign-preserving) */
+  /** $encodingof `... >>> ...` $noteBitvector (logical shift) */
   case class BVLShiftRight(lhs: Expr, rhs: Expr) extends Expr {
     val getType = Int32Type
   }

--- a/src/main/scala/leon/purescala/PrettyPrinter.scala
+++ b/src/main/scala/leon/purescala/PrettyPrinter.scala
@@ -164,6 +164,7 @@ class PrettyPrinter(opts: PrinterOptions,
       case Or(exprs)            => optP { p"${nary(exprs, "| || ")}" } // Ugliness award! The first | is there to shield from stripMargin()
       case Not(Equals(l, r))    => optP { p"$l \u2260 $r" }
       case Implies(l,r)         => optP { p"$l ==> $r" }
+      case BVNot(expr)          => p"~$expr"
       case UMinus(expr)         => p"-$expr"
       case BVUMinus(expr)       => p"-$expr"
       case RealUMinus(expr)     => p"-$expr"

--- a/src/main/scala/leon/utils/DebugSections.scala
+++ b/src/main/scala/leon/utils/DebugSections.scala
@@ -24,6 +24,7 @@ case object DebugSectionXLang        extends DebugSection("xlang",        1 << 1
 case object DebugSectionTypes        extends DebugSection("types",        1 << 13)
 case object DebugSectionIsabelle     extends DebugSection("isabelle",     1 << 14)
 case object DebugSectionReport       extends DebugSection("report",       1 << 15)
+case object DebugSectionGenC         extends DebugSection("genc",         1 << 16)
 
 object DebugSections {
   val all = Set[DebugSection](
@@ -42,6 +43,7 @@ object DebugSections {
     DebugSectionXLang,
     DebugSectionTypes,
     DebugSectionIsabelle,
-    DebugSectionReport
+    DebugSectionReport,
+    DebugSectionGenC
   )
 }

--- a/src/sphinx/genc.rst
+++ b/src/sphinx/genc.rst
@@ -1,0 +1,122 @@
+.. _genc:
+
+Safe C Code
+===========
+
+Leon can generate from Scala code an equivalent and safe C99 code. Using the verification, repair and
+synthesis features of Leon this conversion can be made safely. Additionally, the produced code can be
+compiled with any standard-compliant C99 compiler to target the desired hardware architecture
+without extra dependencies.
+
+To convert a Scala program, one can use the ``--genc`` and ``--o=<output.c>`` command line options
+of Leon.
+
+.. NOTE::
+  Currently the memory model is limited to stack-allocated memory. Hence, no dynamic allocation
+  is done using ``malloc`` function family.
+
+
+Supported Features
+------------------
+
+The supported subset of Scala includes part of the core languages features, as well as some
+extensions from :ref:`XLang <xlang>`, while ensuring the same expression execution order in both
+languages.
+
+Currently all type and function definitions need to be included in one top level object.
+
+
+Types
+*****
+
+The following raw types and their corresponding literals are supported:
+
+.. list-table::
+  :header-rows: 1
+
+  * - Scala
+    - C99
+  * - ``Unit``
+    - ``void``
+  * - ``Boolean``
+    - ``bool``
+  * - ``Int`` (32-bit Integer)
+    - ``int32_t``
+
+Tuples
+^^^^^^
+
+Using ``TupleN[T1, ..., TN]`` results in the creation of a C structure with the same
+fields and types for every combination of any supported type ``T1, ..., TN``. The name of the
+generated structure will be unique and reflect the sequence of types.
+
+
+Arrays
+^^^^^^
+
+``Array[T]`` are implemented using regular C array when the array size is known at compile time, or
+using Variable Length Array (VLA) when the size is only available at runtime. Both types of array
+use the same unique structure type to keep track of the length of the array and its allocated
+memory.
+
+.. NOTE::
+
+  Arrays live on the stack and therefore cannot be returned by functions. This limitation is
+  extended to other types having an array as field.
+
+
+Arrays can be created using the companion object, e.g. ``Array(1, 2, 3)``, or using the
+``Array.fill`` method, e.g. ``Array.fill(size)(value)``.
+
+
+Case Classes
+^^^^^^^^^^^^
+
+The support for classes is restricted to non-recursive case classes for which fields are immutable.
+Instances of such data-types live on the stack.
+
+
+Functions
+*********
+
+Functions and nested functions are supported, with access to the variables in their respective
+scopes. However, higher order functions are as of this moment not supported.
+
+Since strings of characters are currently not available, to generate an executable program, one has
+to define a main function without any argument that returns an integer: ``def main: Int = ...``.
+
+Both ``val`` and ``var`` are supported with the limitations imposed by the :ref:`XLang <xlang>`
+extensions.
+
+
+Constructs
+**********
+
+The idiomatic ``if`` statements such as ``val b = if (x >= 0) true else false`` are converted into
+a sequence of equivalent statements.
+
+Imperative ``while`` loops are also supported.
+
+Assertions, invariant, pre- and post-conditions are not translated into C99 and are simply ignored.
+
+
+Operators
+*********
+
+The following operators are supported:
+
+.. list-table::
+  :header-rows: 1
+
+  * - Category
+    - Operators
+  * - Boolean operators
+    - ``&&``, ``||``, ``!``, ``!=``, ``==``
+  * - Comparision operators over integers
+    - ``<``, ``<=``, ``==``, ``!=``, ``>=``, ``>``
+  * - Arithmetic operators over integers
+    - ``+``, ``-`` (unary & binary), ``*``, ``/``, ``%``
+  * - Bitwise operators over integers
+    - ``&``, ``|``, ``^``, ``~``, ``<<``, ``>>``
+
+

--- a/src/sphinx/index.rst
+++ b/src/sphinx/index.rst
@@ -25,6 +25,7 @@ Contents:
    limitations
    synthesis
    repair
+   genc
    options
    faq
    references

--- a/src/sphinx/options.rst
+++ b/src/sphinx/options.rst
@@ -20,41 +20,46 @@ Choosing which Leon feature to use
 The first group of options determine which feature of Leon will be used.
 These options are mutually exclusive (except when noted). By default, ``--verify`` is chosen.
 
-* ``--eval`` 
- 
+* ``--eval``
+
   Evaluates parameterless functions and value definitions.
-  
+
 * ``--verify``
-  
+
   Proves or disproves function contracts, as explained in the :ref:`verification` section.
 
 * ``--repair``
-  
+
   Runs program :ref:`repair <repair>`.
-  
+
 * ``--synthesis``
-  
+
   Partially synthesizes ``choose()`` constructs (see :ref:`synthesis` section).
 
 * ``--termination``
-  
+
   Runs termination analysis. Can be used along ``--verify``.
 
-* ``--inferInv`` 
+* ``--inferInv``
 
-  Infer invariants from the (instrumented) code (using Orb)
+  Infer invariants from the (instrumented) code (using Orb).
 
-* ``--instrument``                
+* ``--instrument``
 
-  Instrument the code for inferring time/depth/stack bounds (using Orb)
+  Instrument the code for inferring time/depth/stack bounds (using Orb).
+
+* ``--genc``
+
+  Translate a Scala program into C99 equivalent code (see :ref:`genc` section); requires
+  ``--xlang``.
 
 * ``--noop``
-  
+
   Runs the program through the extraction and preprocessing phases, then outputs it in the specified
   directory. Used mostly for debugging purposes.
 
 * ``--help``
-  
+
   Prints a helpful message, then exits.
 
 
@@ -65,44 +70,46 @@ Additional top-level options
 These options are available to all Leon components:
 
 * ``--debug=d1,d2,...``
-  
+
   Enables printing detailed messages for the components d1,d2,... .
-  Available components are: 
+  Available components are:
 
   * ``datagen`` (Data generators)
-  
+
   * ``eval`` (Evaluators)
-  
+
+  * ``genc`` (C code generation)
+
   * ``isabelle`` (:ref:`The Isabelle-based solver <isabelle>`)
 
   * ``leon`` (The top-level component)
-  
+
   * ``options`` (Options parsed by Leon)
- 
+
   * ``positions`` (When printing, attach positions to trees)
 
   * ``repair`` (Program repair)
-  
+
   * ``solver`` (SMT solvers and their wrappers)
-  
+
   * ``synthesis`` (Program synthesis)
-  
+
   * ``termination`` (Termination analysis)
-  
+
   * ``timers`` (Timers, timer pools)
-  
+
   * ``trees`` (Manipulation of trees)
- 
+
   * ``types`` (When printing, attach types to expressions)
 
   * ``verification`` (Verification)
-  
+
   * ``xlang`` (Transformation of XLang into Pure Scala programs)
 
 
 * ``--functions=f1,f2,...``
-  
-  Only consider functions f1, f2, ... . This applies to all functionalities 
+
+  Only consider functions f1, f2, ... . This applies to all functionalities
   where Leon manipulates the input in a per-function basis.
 
   Leon will match against suffixes of qualified names. For instance:
@@ -111,22 +118,22 @@ These options are available to all Leon components:
   This option supports ``_`` as wildcard: ``--functions=List._`` will
   match all ``List`` methods.
 
-* ``--solvers=s1,s2,...`` 
-  
-  Use solvers s1, s2,... . If more than one solver is chosen, all chosen 
+* ``--solvers=s1,s2,...``
+
+  Use solvers s1, s2,... . If more than one solver is chosen, all chosen
   solvers will be used in parallel, and the best result will be presented.
   By default, the ``fairz3`` solver is picked.
- 
-  Some solvers are specialized in proving verification conditions 
-  and will have hard time finding a counterexample in case of an invalid 
+
+  Some solvers are specialized in proving verification conditions
+  and will have hard time finding a counterexample in case of an invalid
   verification condition, whereas some are specialized in finding
   counterexamples, and some provide a compromise between the two.
   Also, some solvers do not as of now support higher-order functions.
 
   Available solvers include:
-  
-  * ``enum`` 
-    
+
+  * ``enum``
+
     Uses enumeration-based techniques to discover counterexamples.
     This solver does not actually invoke an SMT solver,
     and operates entirely on the level of Leon trees.
@@ -134,50 +141,50 @@ These options are available to all Leon components:
   * ``fairz3``
 
     Native Z3 with z3-templates for unfolding recursive functions (default).
-  
+
   * ``smt-cvc4``
-    
-    CVC4 through SMT-LIB. An algorithm within Leon takes up the unfolding 
-    of recursive functions, handling of lambdas etc. To use this or any 
+
+    CVC4 through SMT-LIB. An algorithm within Leon takes up the unfolding
+    of recursive functions, handling of lambdas etc. To use this or any
     of the following CVC4-based solvers, you need to have the ``cvc4``
     executable in your system path (the latest unstable version is recommended).
-  
+
   * ``smt-cvc4-cex``
- 
+
     CVC4 through SMT-LIB, in-solver finite-model-finding, for counter-examples only.
     Recursive functions are not unrolled, but encoded through the
     ``define-funs-rec`` construct available in the new SMTLIB-2.5 standard.
     Currently, this solver does not handle higher-order functions.
-  
+
   * ``smt-cvc4-proof``
-   
-    CVC4 through SMT-LIB, for proofs only. Functions are encoded as in 
+
+    CVC4 through SMT-LIB, for proofs only. Functions are encoded as in
     ``smt-cvc4-cex``.
     Currently, this solver does not handle higher-order functions.
-  
+
   * ``smt-z3``
-   
-    Z3 through SMT-LIB. To use this or the next solver, you need to 
+
+    Z3 through SMT-LIB. To use this or the next solver, you need to
     have the ``z3`` executable in your program path (the latest stable version
     is recommended). Inductive reasoning happens on the Leon side
     (similarly to ``smt-cvc4``).
-  
+
   * ``smt-z3-q``
-   
-    Z3 through SMT-LIB, but (recursive) functions are not unrolled and are 
+
+    Z3 through SMT-LIB, but (recursive) functions are not unrolled and are
     instead encoded with universal quantification.
     For example, ``def foo(x:A) = e`` would be encoded by asserting
-    
+
     .. math::
-    
+
       \forall (x:A). foo(x) = e
 
     even if ``e`` contains an invocation to ``foo``.
 
     Currently, this solver does not handle higher-order functions.
-  
+
   * ``unrollz3``
-    
+
     Native Z3, but inductive reasoning happens within Leon (similarly to ``smt-z3``).
 
   * ``ground``
@@ -187,21 +194,23 @@ These options are available to all Leon components:
   * ``isabelle``
 
     Solve verification conditions via Isabelle.
-  
+
 * ``--strict``
 
-  Terminate Leon after each phase if a non-fatal error is encountered 
+  Terminate Leon after each phase if a non-fatal error is encountered
   (such as a failed verification condition). By default, this option is activated.
 
 * ``--timeout=t``
 
   Set a timeout for each attempt to prove one verification condition/
   repair one function (in sec.)
-    
+
 * ``--xlang``
-  
+
   Support for additional language constructs described in :ref:`xlang`.
-  These constructs are desugared into :ref:`purescala` before other operations.
+  These constructs are desugared into :ref:`purescala` before other operations,
+  except for the ``--genc`` option which uses the original constructs to generate
+  :ref:`genc`.
 
 Additional Options (by component)
 ---------------------------------
@@ -222,9 +231,11 @@ File Output
 ***********
 
 * ``--o=dir``
-  
+
   Output files to the directory ``dir`` (default: leon.out).
   Used when ``--noop`` is selected.
+
+  When used with ``--genc`` this option designates the output *file*.
 
 Code Extraction
 ***************
@@ -245,21 +256,21 @@ Synthesis
   Shrink non-deterministic programs when tests pruning works well.
 
 * ``--cegis:vanuatoo``
- 
+
   Generate inputs using new korat-style generator.
-  
+
 * ``--costmodel=cm``
-  
+
   Use a specific cost model for this search.
   Available: ``Naive``, ``WeightedBranches``
 
 * ``--derivtrees``
-  
+
   Generate a derivation tree for every synthesized function.
   The trees will be output in ``*.dot`` files.
 
 * ``--manual=cmd``
-  
+
   Override Leon's automated search through the space of programs during synthesis.
   Instead, the user can navigate the program space manually
   by choosing which deductive synthesis rules is instantiated each time.
@@ -277,26 +288,26 @@ Fair-z3 Solver
   Double-check counter-examples with evaluator.
 
 * ``--codegen``
-  
+
   Use compiled evaluator instead of interpreter.
 
 * ``--evalground``
- 
+
   Use evaluator on functions applied to ground arguments.
-  
+
 * ``--feelinglucky``
-  
+
   Use evaluator to find counter-examples early.
 
 * ``--unrollcores``
- 
+
   Use unsat-cores to drive unrolling while remaining fair.
-  
+
 CVC4 Solver
 ***********
 
 * ``--solver:cvc4=<cvc4-opt>``
-  
+
   Pass extra command-line arguments to CVC4.
 
 Isabelle

--- a/src/test/resources/regression/genc/invalid/AbsFun.scala
+++ b/src/test/resources/regression/genc/invalid/AbsFun.scala
@@ -1,0 +1,66 @@
+import leon.lang._
+
+object AbsFun {
+
+
+  def isPositive(a : Array[Int], size : Int) : Boolean = {
+    require(a.length >= 0 && size <= a.length)
+    rec(0, a, size)
+  }
+
+  def rec(i: Int, a: Array[Int], size: Int) : Boolean = {
+    require(a.length >= 0 && size <= a.length && i >= 0)
+
+    if(i >= size) true
+    else {
+      if (a(i) < 0)
+        false
+      else
+        rec(i + 1, a, size)
+    }
+  }
+
+  // Returning Arrays is not supported by GenC
+  def abs(tab: Array[Int]): Array[Int] = {
+    require(tab.length >= 0)
+    val t = while0(Array.fill(tab.length)(0), 0, tab)
+    t._1
+  } ensuring(res => isPositive(res, res.length))
+
+
+  def while0(t: Array[Int], k: Int, tab: Array[Int]): (Array[Int], Int) = {
+    require(tab.length >= 0 &&
+            t.length == tab.length &&
+            k >= 0 &&
+            k <= tab.length &&
+            isPositive(t, k))
+
+    if(k < tab.length) {
+      val nt = if(tab(k) < 0) {
+        t.updated(k, -tab(k))
+      } else {
+        t.updated(k, tab(k))
+      }
+      while0(nt, k+1, tab)
+    } else {
+      (t, k)
+    }
+  } ensuring(res =>
+      res._2 >= tab.length &&
+      res._1.length == tab.length &&
+      res._2 >= 0 &&
+      res._2 <= tab.length &&
+      isPositive(res._1, res._2))
+
+  def property(t: Array[Int], k: Int): Boolean = {
+    require(isPositive(t, k) && t.length >= 0 && k >= 0)
+    if(k < t.length) {
+      val nt = if(t(k) < 0) {
+        t.updated(k, -t(k))
+      } else {
+        t.updated(k, t(k))
+      }
+      isPositive(nt, k+1)
+    } else true
+  } holds
+}

--- a/src/test/resources/regression/genc/invalid/LinearSearch.scala
+++ b/src/test/resources/regression/genc/invalid/LinearSearch.scala
@@ -1,0 +1,40 @@
+import leon.lang._
+
+/* The calculus of Computation textbook */
+
+object LinearSearch {
+
+  def linearSearch(a: Array[Int], c: Int): Boolean = ({
+    require(a.length >= 0)
+    var i = 0
+    var found = false
+    (while(i < a.length) {
+      if(a(i) == c)
+        found = true
+      i = i + 1
+    }) invariant(
+         i <= a.length &&
+         i >= 0 &&
+         (if(found) contains(a, i, c) else !contains(a, i, c))
+       )
+    found
+  }) ensuring(res => if(res) contains(a, a.length, c) else !contains(a, a.length, c))
+
+  def contains(a: Array[Int], size: Int, c: Int): Boolean = {
+    require(a.length >= 0 && size >= 0 && size <= a.length)
+    content(a, size).contains(c)
+  }
+
+  // Set not supported by GenC
+  def content(a: Array[Int], size: Int): Set[Int] = {
+    require(a.length >= 0 && size >= 0 && size <= a.length)
+    var set = Set.empty[Int]
+    var i = 0
+    (while(i < size) {
+      set = set ++ Set(a(i))
+      i = i + 1
+    }) invariant(i >= 0 && i <= size)
+    set
+  }
+
+}

--- a/src/test/resources/regression/genc/unverified/BinarySearch.scala
+++ b/src/test/resources/regression/genc/unverified/BinarySearch.scala
@@ -11,7 +11,8 @@ object BinarySearch {
     var res = -1
 
     (while(low <= high && res == -1) {
-      val i = (high + low) / 2
+      //val i = (high + low) / 2
+      val i = low + ((high - low) / 2)
       val v = a(i)
 
       if(v == key)

--- a/src/test/resources/regression/genc/unverified/BinarySearchFun.scala
+++ b/src/test/resources/regression/genc/unverified/BinarySearchFun.scala
@@ -7,20 +7,24 @@ object BinarySearchFun {
         0 <= low && low <= high + 1 && high < a.length
     )
 
-    if(low <= high) {
-      val i = (high + low) / 2
+    if (low <= high) {
+      //val i = (high + low) / 2
+      val i = low + (high - low) / 2
+
       val v = a(i)
 
-      if(v == key) i
+      if (v == key) i
       else if (v > key) binarySearch(a, key, low, i - 1)
       else binarySearch(a, key, i + 1, high)
     } else -1
   }) ensuring(res =>
       res >= -1 &&
-      res < a.length &&
-      (if (res >= 0)
-          a(res) == key else
-          (high < 0 || (!occurs(a, low, (high+low)/2, key) && !occurs(a, (high+low)/2, high, key)))
+      res < a.length && (
+      if (res >= 0)
+        a(res) == key
+      else
+        (high < 0 || (!occurs(a, low, low + (high - low) / 2, key) &&
+                      !occurs(a, low + (high - low) / 2, high, key)))
       )
     )
 
@@ -29,13 +33,13 @@ object BinarySearchFun {
     require(a.length >= 0 && to <= a.length && from >= 0)
     def rec(i: Int): Boolean = {
       require(i >= 0)
-      if(i >= to)
+      if (i >= to)
         false
       else {
-       if(a(i) == key) true else rec(i+1)
+       if (a(i) == key) true else rec(i+1)
       }
     }
-    if(from >= to)
+    if (from >= to)
       false
     else
       rec(from)

--- a/src/test/resources/regression/genc/unverified/MaxSum.scala
+++ b/src/test/resources/regression/genc/unverified/MaxSum.scala
@@ -65,7 +65,7 @@ object MaxSum {
     val max = sm._2
     if (sum == 1244 && max == 999) 0
     else -1
-  }
+  } ensuring { _ == 0 }
 
 }
 

--- a/src/test/resources/regression/genc/valid/AbsArray.scala
+++ b/src/test/resources/regression/genc/valid/AbsArray.scala
@@ -1,21 +1,23 @@
 import leon.lang._
 
 object AbsArray {
-  def abs(a: Array[Int]) {
-    var i = 0;
-    while (i < a.length) {
-      a(i) = if (a(i) < 0) -a(i) else a(i)
-      i = i + 1
-    }
-  }
-
   def main = {
     val a = Array(0, -1, 2, -3)
 
-    abs(a)
+    def abs() {
+      require(a.length < 10000)
+
+      var i = 0;
+      (while (i < a.length && i < 10000) {
+        a(i) = if (a(i) < 0) -a(i) else a(i)
+        i = i + 1
+      }) invariant (i >= 0 && i <= 10000)
+    }
+
+    abs()
 
     a(0) + a(1) - 1 + a(2) - 2 + a(3) - 3 // == 0
-  }
+  } ensuring { _ == 0 }
 }
 
 

--- a/src/test/resources/regression/genc/valid/AbsArray.scala
+++ b/src/test/resources/regression/genc/valid/AbsArray.scala
@@ -1,0 +1,21 @@
+import leon.lang._
+
+object AbsArray {
+  def abs(a: Array[Int]) {
+    var i = 0;
+    while (i < a.length) {
+      a(i) = if (a(i) < 0) -a(i) else a(i)
+      i = i + 1
+    }
+  }
+
+  def main = {
+    val a = Array(0, -1, 2, -3)
+
+    abs(a)
+
+    a(0) + a(1) - 1 + a(2) - 2 + a(3) - 3 // == 0
+  }
+}
+
+

--- a/src/test/resources/regression/genc/valid/BinarySearch.scala
+++ b/src/test/resources/regression/genc/valid/BinarySearch.scala
@@ -1,0 +1,81 @@
+import leon.lang._
+
+/* VSTTE 2008 - Dafny paper */
+
+object BinarySearch {
+
+  def binarySearch(a: Array[Int], key: Int): Int = ({
+    require(a.length > 0 && sorted(a, 0, a.length - 1))
+    var low = 0
+    var high = a.length - 1
+    var res = -1
+
+    (while(low <= high && res == -1) {
+      val i = (high + low) / 2
+      val v = a(i)
+
+      if(v == key)
+        res = i
+
+      if(v > key)
+        high = i - 1
+      else if(v < key)
+        low = i + 1
+    }) invariant(
+        res >= -1 &&
+        res < a.length &&
+        0 <= low &&
+        low <= high + 1 &&
+        high >= -1 &&
+        high < a.length &&
+        (if (res >= 0)
+            a(res) == key else
+            (!occurs(a, 0, low, key) && !occurs(a, high + 1, a.length, key))
+        )
+       )
+    res
+  }) ensuring(res =>
+      res >= -1 &&
+      res < a.length &&
+      (if(res >= 0) a(res) == key else !occurs(a, 0, a.length, key)))
+
+
+  def occurs(a: Array[Int], from: Int, to: Int, key: Int): Boolean = {
+    require(a.length >= 0 && to <= a.length && from >= 0)
+    def rec(i: Int): Boolean = {
+      require(i >= 0)
+      if(i >= to)
+        false
+      else {
+       if(a(i) == key) true else rec(i+1)
+      }
+    }
+    if(from >= to)
+      false
+    else
+      rec(from)
+  }
+
+
+  def sorted(a: Array[Int], l: Int, u: Int) : Boolean = {
+    require(a.length >= 0 && l >= 0 && l <= u && u < a.length)
+    val t = sortedWhile(true, l, l, u, a)
+    t._1
+  }
+
+  def sortedWhile(isSorted: Boolean, k: Int, l: Int, u: Int, a: Array[Int]): (Boolean, Int) = {
+    require(a.length >= 0 && l >= 0 && l <= u && u < a.length && k >= l && k <= u)
+    if(k < u) {
+      sortedWhile(if(a(k) > a(k + 1)) false else isSorted, k + 1, l, u, a)
+    } else (isSorted, k)
+  }
+
+
+  def main = {
+    val a = Array(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+    val i = binarySearch(a, 2)
+    i - 2 // i should be 2
+  }
+
+}
+

--- a/src/test/resources/regression/genc/valid/BinarySearchFun.scala
+++ b/src/test/resources/regression/genc/valid/BinarySearchFun.scala
@@ -1,0 +1,66 @@
+import leon.lang._
+
+object BinarySearchFun {
+
+  def binarySearch(a: Array[Int], key: Int, low: Int, high: Int): Int = ({
+    require(a.length > 0 && sorted(a, low, high) &&
+        0 <= low && low <= high + 1 && high < a.length
+    )
+
+    if(low <= high) {
+      val i = (high + low) / 2
+      val v = a(i)
+
+      if(v == key) i
+      else if (v > key) binarySearch(a, key, low, i - 1)
+      else binarySearch(a, key, i + 1, high)
+    } else -1
+  }) ensuring(res =>
+      res >= -1 &&
+      res < a.length &&
+      (if (res >= 0)
+          a(res) == key else
+          (high < 0 || (!occurs(a, low, (high+low)/2, key) && !occurs(a, (high+low)/2, high, key)))
+      )
+    )
+
+
+  def occurs(a: Array[Int], from: Int, to: Int, key: Int): Boolean = {
+    require(a.length >= 0 && to <= a.length && from >= 0)
+    def rec(i: Int): Boolean = {
+      require(i >= 0)
+      if(i >= to)
+        false
+      else {
+       if(a(i) == key) true else rec(i+1)
+      }
+    }
+    if(from >= to)
+      false
+    else
+      rec(from)
+  }
+
+
+  def sorted(a: Array[Int], l: Int, u: Int) : Boolean = {
+    require(a.length >= 0 && l >= 0 && l <= u + 1 && u < a.length)
+    val t = sortedWhile(true, l, l, u, a)
+    t._1
+  }
+
+  def sortedWhile(isSorted: Boolean, k: Int, l: Int, u: Int, a: Array[Int]): (Boolean, Int) = {
+    require(a.length >= 0 && l >= 0 && l <= u+1 && u < a.length && k >= l && k <= u + 1)
+    if(k < u) {
+      sortedWhile(if(a(k) > a(k + 1)) false else isSorted, k + 1, l, u, a)
+    } else (isSorted, k)
+  }
+
+  def main = {
+    val a = Array(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+    val i = binarySearch(a, 2, 0, a.length - 1) // should be 2
+    val j = binarySearch(a, 11, 0, a.length - 1) // should be -1
+
+    (i - 2) + (j + 1) // == 0
+  }
+}
+

--- a/src/test/resources/regression/genc/valid/CaseClass.scala
+++ b/src/test/resources/regression/genc/valid/CaseClass.scala
@@ -1,0 +1,19 @@
+import leon.lang._
+
+object CaseClass {
+
+  case class Color(r: Int, g: Int, b: Int)
+
+  def red  = Color(0, 255, 0)
+  def cyan = Color(0, 255, 255)
+
+  def sub(c: Color, d: Color) = Color(c.r - d.r, c.g - d.g, c.b - d.b)
+
+  def main = {
+    val c = red
+    val d = cyan
+    val z = sub(c, d).g
+    z
+  }
+
+}

--- a/src/test/resources/regression/genc/valid/CaseClass.scala
+++ b/src/test/resources/regression/genc/valid/CaseClass.scala
@@ -14,6 +14,7 @@ object CaseClass {
     val d = cyan
     val z = sub(c, d).g
     z
-  }
+  } ensuring { _ == 0 }
 
 }
+

--- a/src/test/resources/regression/genc/valid/ExpressionOrder.scala
+++ b/src/test/resources/regression/genc/valid/ExpressionOrder.scala
@@ -9,7 +9,7 @@ object ExpressionOrder {
   def bar(i: Int) = i * 2
   def baz(i: Int, j: Int) = bar(i) - bar(j)
 
-  def syntaxCheck {
+  def syntaxCheck(i: Int) {
     val p = Pixel(fun)
     val m = Matrix(Array(0, 1, 2, 3), 2, 2)
 
@@ -17,6 +17,21 @@ object ExpressionOrder {
     val a = Array(0, 1, foo / 2, 3, bar(2), z / 1)
 
     val t = (true, foo, bar(a(0)))
+
+    val a2 = Array.fill(4)(2)
+    val a3 = Array.fill(if (i <= 0) 1 else i)(bar(i))
+    val b = Array(1, 2, 0)
+    b(1) = if (bar(b(1)) % 2 == 0) 42 else 58
+
+    def f1 = (if (i < 0) a else b)(0)
+    def f2 = (if (i < 0) a else b).length
+
+    //def f3 = (if (i < 0) a else b)(0) = 0 // <- not supported
+
+    val c = (0, true, 2)
+    val d = (if (i > 0) i else -i, false, 0)
+
+    def f4 = (if (i < 0) d else c)._2 // expression result unused
   }
 
   def main =

--- a/src/test/resources/regression/genc/valid/ExpressionOrder.scala
+++ b/src/test/resources/regression/genc/valid/ExpressionOrder.scala
@@ -1,0 +1,119 @@
+import leon.lang._
+
+object ExpressionOrder {
+  case class Pixel(rgb: Int)
+  case class Matrix(data: Array[Int], w: Int, h: Int)
+
+  def fun = 0xffffff
+  def foo = 4
+  def bar(i: Int) = i * 2
+  def baz(i: Int, j: Int) = bar(i) - bar(j)
+
+  def syntaxCheck {
+    val p = Pixel(fun)
+    val m = Matrix(Array(0, 1, 2, 3), 2, 2)
+
+    val z = baz(foo, bar(foo))
+    val a = Array(0, 1, foo / 2, 3, bar(2), z / 1)
+
+    val t = (true, foo, bar(a(0)))
+  }
+
+  def main =
+      bool2int(test0(false), 1)  +
+      bool2int(test1(42),    2)  +
+      bool2int(test2(58),    4)  +
+      bool2int(test3(false), 8)  +
+      bool2int(test4(false), 16) +
+      bool2int(test6,        32) +
+      bool2int(test7,        64)
+
+  def test0(b: Boolean) = {
+    val f = b && !b // == false
+
+    var c = 0
+
+    val x = f && { c = 1; true }
+
+    c == 0
+  }
+
+  def test1(i: Int) = {
+    require(i > 0)
+
+    val j = i / i * 3 // == 3
+
+    var c = 0
+    val x = { c = c + 3; j } + { c = c + 1; j } * { c = c * 2; j }
+
+    c == 8 && j == 3 && x == 12
+  }
+
+  def test2(i: Int) = {
+    var c = 0;
+    val x = if (i < 0) { c = 1; -i } else { c = 2; i }
+
+    if (i < 0) c == 1
+    else c == 2
+  }
+
+  def test3(b: Boolean) = {
+    val f = b && !b // == false
+
+    var c = 0
+    val x = f || { c = 1; true } || { c = 2; false }
+
+    c == 1
+  }
+
+  def test4(b: Boolean) = {
+    var i = 10
+    var c = 0
+
+    val f = b && !b // == false
+    val t = b || !b // == true
+
+    // The following condition is executed 11 times,
+    // and only during the last execution is the last
+    // operand evaluated
+    while ({ c = c + 1; t } && i > 0 || { c = c * 2; f }) {
+      i = i - 1
+    }
+
+    i == 0 && c == 22
+  }
+
+  def test5(b: Boolean) = {
+    val f = b && !b // == false
+
+    var c = if (f) 0 else -1
+
+    c = c + (if (f) 0 else 1)
+
+    c == 0
+  }
+
+  def test6 = {
+    val a = Array(0, 1, 2, 3, 4)
+    def rec(b: Boolean, i: Int): Boolean = {
+      if (a.length <= i + 1) b
+      else rec(if (a(i) < a(i + 1)) b else false, i + 1)
+    }
+
+    rec(true, 0)
+  }
+
+  def test7 = {
+    var c = 1
+
+    val a = Array(0, 1, 2, 3, 4)
+
+    a(if(a(0) == 0) { c = c + 1; 0 } else { c = c + 2; 1 }) = { c = c * 2; -1 }
+
+    c == 4
+  }
+
+  def bool2int(b: Boolean, f: Int) = if (b) 0 else f;
+}
+
+

--- a/src/test/resources/regression/genc/valid/ExpressionOrder.scala
+++ b/src/test/resources/regression/genc/valid/ExpressionOrder.scala
@@ -34,7 +34,7 @@ object ExpressionOrder {
     def f4 = (if (i < 0) d else c)._2 // expression result unused
   }
 
-  def main =
+  def main = {
       bool2int(test0(false), 1)  +
       bool2int(test1(42),    2)  +
       bool2int(test2(58),    4)  +
@@ -43,6 +43,7 @@ object ExpressionOrder {
       bool2int(test6,        32) +
       bool2int(test7,        64) +
       bool2int(test8,        128)
+  } ensuring { _ == 0 }
 
   def test0(b: Boolean) = {
     val f = b && !b // == false
@@ -52,7 +53,7 @@ object ExpressionOrder {
     val x = f && { c = 1; true }
 
     c == 0
-  }
+  }.holds
 
   def test1(i: Int) = {
     require(i > 0)
@@ -63,7 +64,7 @@ object ExpressionOrder {
     val x = { c = c + 3; j } + { c = c + 1; j } * { c = c * 2; j }
 
     c == 8 && j == 3 && x == 12
-  }
+  }.holds
 
   def test2(i: Int) = {
     var c = 0;
@@ -71,7 +72,7 @@ object ExpressionOrder {
 
     if (i < 0) c == 1
     else c == 2
-  }
+  }.holds
 
   def test3(b: Boolean) = {
     val f = b && !b // == false
@@ -80,7 +81,7 @@ object ExpressionOrder {
     val x = f || { c = 1; true } || { c = 2; false }
 
     c == 1
-  }
+  }.holds
 
   def test4(b: Boolean) = {
     var i = 10
@@ -97,7 +98,7 @@ object ExpressionOrder {
     }
 
     i == 0 && c == 22
-  }
+  }.holds
 
   def test5(b: Boolean) = {
     val f = b && !b // == false
@@ -107,17 +108,20 @@ object ExpressionOrder {
     c = c + (if (f) 0 else 1)
 
     c == 0
-  }
+  }.holds
 
   def test6 = {
     val a = Array(0, 1, 2, 3, 4)
+
     def rec(b: Boolean, i: Int): Boolean = {
-      if (a.length <= i + 1) b
-      else rec(if (a(i) < a(i + 1)) b else false, i + 1)
+      require(i >= 0 && i < 2147483647) // 2^31 - 1
+
+      if (i + 1 < a.length) rec(if (a(i) < a(i + 1)) b else false, i + 1)
+      else b
     }
 
     rec(true, 0)
-  }
+  }.holds
 
   def test7 = {
     var c = 1
@@ -127,7 +131,7 @@ object ExpressionOrder {
     a(if(a(0) == 0) { c = c + 1; 0 } else { c = c + 2; 1 }) = { c = c * 2; -1 }
 
     c == 4
-  }
+  }.holds
 
   def test8 = {
     var x = 0
@@ -139,7 +143,7 @@ object ExpressionOrder {
     }
 
     bar(2) == 0
-  }
+  }.holds
 
   def bool2int(b: Boolean, f: Int) = if (b) 0 else f;
 }

--- a/src/test/resources/regression/genc/valid/ExpressionOrder.scala
+++ b/src/test/resources/regression/genc/valid/ExpressionOrder.scala
@@ -4,6 +4,8 @@ object ExpressionOrder {
   case class Pixel(rgb: Int)
   case class Matrix(data: Array[Int], w: Int, h: Int)
 
+  def void = ()
+
   def fun = 0xffffff
   def foo = 4
   def bar(i: Int) = i * 2

--- a/src/test/resources/regression/genc/valid/ExpressionOrder.scala
+++ b/src/test/resources/regression/genc/valid/ExpressionOrder.scala
@@ -41,7 +41,8 @@ object ExpressionOrder {
       bool2int(test3(false), 8)  +
       bool2int(test4(false), 16) +
       bool2int(test6,        32) +
-      bool2int(test7,        64)
+      bool2int(test7,        64) +
+      bool2int(test8,        128)
 
   def test0(b: Boolean) = {
     val f = b && !b // == false
@@ -126,6 +127,18 @@ object ExpressionOrder {
     a(if(a(0) == 0) { c = c + 1; 0 } else { c = c + 2; 1 }) = { c = c * 2; -1 }
 
     c == 4
+  }
+
+  def test8 = {
+    var x = 0
+
+    def bar(y: Int) = {
+      def fun(z: Int) = 1 * x * (y + z)
+
+      fun(3)
+    }
+
+    bar(2) == 0
   }
 
   def bool2int(b: Boolean, f: Int) = if (b) 0 else f;

--- a/src/test/resources/regression/genc/valid/IntegralColor.scala
+++ b/src/test/resources/regression/genc/valid/IntegralColor.scala
@@ -65,7 +65,7 @@ object IntegralColor {
     val expected = Array(159, 52, 255, 0) // gray convertion
     val gray     = Array.fill(4)(0)
 
-    // NOTE: Cannot define toGray function as XLang doesn't allow mutating
+    // NOTE: Cannot define a toGray function as XLang doesn't allow mutating
     // arguments and GenC doesn't allow returning arrays
 
     var idx = 0
@@ -145,7 +145,7 @@ object IntegralColor {
     val expected = Array(124, 158, 76, 73)
     val size = 2 // grey is size x size
 
-    // NOTE: Cannot define toGray function as XLang doesn't allow mutating
+    // NOTE: Cannot define a `smoothed` function as XLang doesn't allow mutating
     // arguments and GenC doesn't allow returning arrays
 
     val kernel = Kernel(3, Array(1, 1, 1,

--- a/src/test/resources/regression/genc/valid/IntegralColor.scala
+++ b/src/test/resources/regression/genc/valid/IntegralColor.scala
@@ -1,0 +1,175 @@
+import leon.lang._
+
+object IntegralColor {
+
+  def isValidComponent(x: Int) = x >= 0 && x <= 255
+
+  def getRed(rgb: Int): Int = {
+    (rgb & 0x00FF0000) >> 16
+  } ensuring isValidComponent _
+
+  def getGreen(rgb: Int): Int = {
+    (rgb & 0x0000FF00) >> 8
+  } ensuring isValidComponent _
+
+  def getBlue(rgb: Int): Int = {
+    rgb & 0x000000FF
+  } ensuring isValidComponent _
+
+  def getGray(rgb: Int): Int = {
+    (getRed(rgb) + getGreen(rgb) + getBlue(rgb)) / 3
+  } ensuring isValidComponent _
+
+  def testColorSinglePixel: Boolean = {
+    val color = 0x20C0FF
+
+    32 == getRed(color) && 192 == getGreen(color) &&
+    255 == getBlue(color) && 159 == getGray(color)
+  }.holds
+
+  case class Color(r: Int, g: Int, b: Int)
+
+  def getColor(rgb: Int) = Color(getRed(rgb), getGreen(rgb), getBlue(rgb))
+
+  /*
+   *case class Image(width: Int, height: Int, buffer: Array[Int]) {
+   *  // currently not enforced:
+   *  require(width <= 1000 && height <= 1000 && buffer.length == width * height)
+   *}
+   */
+
+  def matches(value: Array[Int], expected: Array[Int]): Boolean = {
+    require(value.length == expected.length)
+
+    var test = true
+    var idx = 0
+    (while (idx < value.length) {
+      test = test && value(idx) == expected(idx)
+      idx = idx + 1
+    }) invariant { idx >= 0 && idx <= value.length }
+
+    test
+  }
+
+  def testColorWholeImage: Boolean = {
+    val WIDTH  = 2
+    val HEIGHT = 2
+
+    /*
+     *val source   = Image(WIDTH, HEIGHT, Array(0x20c0ff, 0x123456, 0xffffff, 0x000000))
+     *val expected = Image(WIDTH, HEIGHT, Array(159, 52, 255, 0)) // gray convertion
+     *val gray     = Image(WIDTH, HEIGHT, Array.fill(4)(0))
+     */
+
+    val source   = Array(0x20c0ff, 0x123456, 0xffffff, 0x000000)
+    val expected = Array(159, 52, 255, 0) // gray convertion
+    val gray     = Array.fill(4)(0)
+
+    // NOTE: Cannot define toGray function as XLang doesn't allow mutating
+    // arguments and GenC doesn't allow returning arrays
+
+    var idx = 0
+    (while (idx < WIDTH * HEIGHT) {
+      gray(idx) = getGray(source(idx))
+      idx = idx + 1
+    }) invariant { idx >= 0 && idx <= WIDTH * HEIGHT && gray.length == WIDTH * HEIGHT }
+    // NB: the last invariant is very important -- without it the verification times out
+
+    matches(gray, expected)
+  }.holds
+
+  // Only for square kernels
+  case class Kernel(size: Int, buffer: Array[Int])
+
+  def isKernelValid(kernel: Kernel): Boolean =
+    kernel.size > 0 && kernel.size < 1000 && kernel.size % 2 == 1 &&
+    kernel.buffer.length == kernel.size * kernel.size
+
+  def applyFilter(gray: Array[Int], size: Int, idx: Int, kernel: Kernel): Int = {
+    require(size > 0 && size < 1000 &&
+            gray.length == size * size &&
+            idx >= 0 && idx < gray.length &&
+            isKernelValid(kernel))
+
+    def up(x: Int): Int = {
+      if (x < 0) 0 else x
+    } ensuring { _ >= 0 }
+
+    def down(x: Int): Int = {
+      if (x >= size) size - 1 else x
+    } ensuring { _ < size }
+
+    def fix(x: Int): Int = {
+      down(up(x))
+    } ensuring { res => res >= 0 && res < size }
+
+    def at(row: Int, col: Int): Int = {
+      val r = fix(row)
+      val c = fix(col)
+
+      gray(r * size + c)
+    }
+
+    val mid = kernel.size / 2
+
+    val i = idx / size
+    val j = idx % size
+
+    var res = 0
+    var p = -mid
+    (while (p <= mid) {
+      var q = -mid
+
+      (while (q <= mid) {
+        val krow = p + mid
+        val kcol = q + mid
+
+        assert(krow >= 0 && krow < kernel.size)
+        assert(kcol >= 0 && kcol < kernel.size)
+
+        val kidx = krow * kernel.size + kcol
+
+        res += at(i + p, j + q) * kernel.buffer(kidx)
+
+        q = q + 1
+      }) invariant { q >= -mid && q <= mid + 1 }
+
+      p = p + 1
+    }) invariant { p >= -mid && p <= mid + 1 }
+
+    res
+  }
+
+  def testFilterConvolutionSmooth: Boolean = {
+    val gray = Array(127, 255, 51, 0)
+    val expected = Array(124, 158, 76, 73)
+    val size = 2 // grey is size x size
+
+    // NOTE: Cannot define toGray function as XLang doesn't allow mutating
+    // arguments and GenC doesn't allow returning arrays
+
+    val kernel = Kernel(3, Array(1, 1, 1,
+                                 1, 2, 1,
+                                 1, 1, 1))
+
+    val smoothed = Array.fill(gray.length)(0)
+    assert(smoothed.length == expected.length)
+
+    var idx = 0;
+    (while (idx < smoothed.length) {
+      smoothed(idx) = applyFilter(gray, size, idx, kernel) / 10
+      idx = idx + 1
+    }) invariant { idx >= 0 && idx <= smoothed.length && smoothed.length == gray.length }
+
+    matches(smoothed, expected)
+  }.holds
+
+
+  def main: Int = {
+    if (testColorSinglePixel && testColorWholeImage && testFilterConvolutionSmooth) 0
+    else 1
+  } ensuring { _ == 0 }
+
+}
+
+

--- a/src/test/resources/regression/genc/valid/MaxSum.scala
+++ b/src/test/resources/regression/genc/valid/MaxSum.scala
@@ -1,0 +1,71 @@
+import leon.lang._
+
+/* VSTTE 2010 challenge 1 */
+
+object MaxSum {
+
+  def maxSum(a: Array[Int]): (Int, Int) = ({
+    require(a.length >= 0 && isPositive(a))
+    var sum = 0
+    var max = 0
+    var i = 0
+    (while(i < a.length) {
+      if(max < a(i))
+        max = a(i)
+      sum = sum + a(i)
+      i = i + 1
+    }) invariant (sum <= i * max && i >= 0 && i <= a.length)
+    (sum, max)
+  }) ensuring(res => res._1 <= a.length * res._2)
+
+
+  def isPositive(a: Array[Int]): Boolean = {
+    require(a.length >= 0)
+    def rec(i: Int): Boolean = {
+      require(i >= 0)
+      if(i >= a.length)
+        true
+      else {
+        if(a(i) < 0)
+          false
+        else
+          rec(i+1)
+      }
+    }
+    rec(0)
+  }
+
+  def summ(to : Int): Int = ({
+    require(to >= 0)
+    var i = 0
+    var s = 0
+    (while (i < to) {
+      s = s + i
+      i = i + 1
+    }) invariant (s >= 0 && i >= 0 && s == i*(i-1)/2 && i <= to)
+    s
+  }) ensuring(res => res >= 0 && res == to*(to-1)/2)
+
+
+  def sumsq(to : Int): Int = ({
+    require(to >= 0)
+    var i = 0
+    var s = 0
+    (while (i < to) {
+      s = s + i*i
+      i = i + 1
+    }) invariant (s >= 0 && i >= 0 && s == (i-1)*i*(2*i-1)/6 && i <= to)
+    s
+  }) ensuring(res => res >= 0 && res == (to-1)*to*(2*to-1)/6)
+
+  def main = {
+    val a = Array(1, 4, 6, 0, 234, 999)
+    val sm = maxSum(a)
+    val sum = sm._1
+    val max = sm._2
+    if (sum == 1244 && max == 999) 0
+    else -1
+  }
+
+}
+

--- a/src/test/resources/regression/genc/valid/RecursionAndNestedFunctions.scala
+++ b/src/test/resources/regression/genc/valid/RecursionAndNestedFunctions.scala
@@ -1,0 +1,34 @@
+import leon.lang._
+
+object RecursionAndNestedFunctions {
+
+  // Complex way to return i
+  def zzz(i: Int): Int = {
+    val x = 0
+    def rec(j: Int): Int = {
+      if (i - x == j)     i
+      else if (j > i) rec(j - 1)
+      else            rec(j + 1)
+    }
+
+    rec(4)
+  }
+
+
+  // Complex way to compute 100 + 2 * i
+  def foo(i: Int) = {
+    var j = i
+    def bar(x: Int) = {
+      //j = j - 1 <- not supported by leon
+      val y = x + i
+      def baz(z: Int) = z + y + i
+      //j = j + 1 <- not supported by leon
+      baz(42)
+    }
+    bar(58) + j - i
+  }
+
+  def main() = foo(2) - zzz(104)
+
+}
+

--- a/src/test/resources/regression/genc/valid/RecursionAndNestedFunctions.scala
+++ b/src/test/resources/regression/genc/valid/RecursionAndNestedFunctions.scala
@@ -5,14 +5,15 @@ object RecursionAndNestedFunctions {
   // Complex way to return i
   def zzz(i: Int): Int = {
     val x = 0
+
     def rec(j: Int): Int = {
-      if (i - x == j)     i
+      if (i - x == j) i
       else if (j > i) rec(j - 1)
       else            rec(j + 1)
-    }
+    } ensuring { _ == i }
 
     rec(4)
-  }
+  } ensuring { _ == i }
 
 
   // Complex way to compute 100 + 2 * i
@@ -26,9 +27,11 @@ object RecursionAndNestedFunctions {
       baz(42)
     }
     bar(58) + j - i
-  }
+  } ensuring { _ == 100 + 2 * i }
 
-  def main() = foo(2) - zzz(104)
+  def main() = {
+    foo(2) - zzz(104)
+  } ensuring { _ == 0 }
 
 }
 

--- a/src/test/resources/regression/genc/valid/TupleArray.scala
+++ b/src/test/resources/regression/genc/valid/TupleArray.scala
@@ -2,12 +2,14 @@ import leon.lang._
 
 object TupleArray {
   def exists(av: (Array[Int], Int)): Boolean = {
-    var i = 0;
-    var found = false;
-    while (!found && i < av._1.length) {
+    require(av._1.length < 10000)
+
+    var i = 0
+    var found = false
+    (while (!found && i < av._1.length) {
       found = av._1(i) == av._2
       i = i + 1
-    }
+    }) invariant (i >= 0 && i < 10000)
     found
   }
 
@@ -17,6 +19,7 @@ object TupleArray {
     val e2 = exists((a, -1))
     if (e1 && !e2) 0
     else -1
-  }
+  } ensuring { _ == 0 }
 
 }
+

--- a/src/test/resources/regression/genc/valid/TupleArray.scala
+++ b/src/test/resources/regression/genc/valid/TupleArray.scala
@@ -1,0 +1,22 @@
+import leon.lang._
+
+object TupleArray {
+  def exists(av: (Array[Int], Int)): Boolean = {
+    var i = 0;
+    var found = false;
+    while (!found && i < av._1.length) {
+      found = av._1(i) == av._2
+      i = i + 1
+    }
+    found
+  }
+
+  def main = {
+    val a = Array(0, 1, 5, -5, 9)
+    val e1 = exists((a, 0))
+    val e2 = exists((a, -1))
+    if (e1 && !e2) 0
+    else -1
+  }
+
+}

--- a/src/test/resources/regression/termination/valid/QuickSort.scala
+++ b/src/test/resources/regression/termination/valid/QuickSort.scala
@@ -1,5 +1,6 @@
 /* Copyright 2009-2015 EPFL, Lausanne */
 
+import leon.annotation._
 import leon.lang._
 
 object QuickSort {
@@ -29,7 +30,7 @@ object QuickSort {
     case Nil() => bList
     case _ => rev_append(reverse(aList),bList)
   }
-  
+
   def greater(n:Int,list:List) : List = list match {
     case Nil() => Nil()
     case Cons(x,xs) => if (n < x) Cons(x,greater(n,xs)) else greater(n,xs)
@@ -51,6 +52,7 @@ object QuickSort {
     case Cons(x,xs) => append(append(quickSort(smaller(x,xs)),Cons(x,equals(x,xs))),quickSort(greater(x,xs)))
   }) ensuring(res => contents(res) == contents(list)) // && is_sorted(res))
 
+  @ignore
   def main(args: Array[String]): Unit = {
     val ls: List = Cons(5, Cons(2, Cons(4, Cons(5, Cons(1, Cons(8,Nil()))))))
 

--- a/src/test/resources/regression/termination/valid/SimpInterpret.scala
+++ b/src/test/resources/regression/termination/valid/SimpInterpret.scala
@@ -1,15 +1,15 @@
 /* Copyright 2009-2015 EPFL, Lausanne */
 
-//import leon.annotation._
+import leon.annotation._
 import leon.lang._
 
 object Interpret {
-  abstract class BoolTree 
+  abstract class BoolTree
   case class Eq(t1 : IntTree, t2 : IntTree) extends BoolTree
   case class And(t1 : BoolTree, t2 : BoolTree) extends BoolTree
   case class Not(t : BoolTree) extends BoolTree
 
-  abstract class IntTree 
+  abstract class IntTree
   case class Const(c:Int) extends IntTree
   case class Var() extends IntTree
   case class Plus(t1 : IntTree, t2 : IntTree) extends IntTree
@@ -22,7 +22,7 @@ object Interpret {
   }
 
   def beval(t:BoolTree, x0 : Int) : Boolean = {
-    t match {   
+    t match {
       case Less(t1, t2) => ieval(t1,x0) < ieval(t2,x0)
       case Eq(t1, t2) => ieval(t1,x0) == ieval(t2,x0)
       case And(t1, t2) => beval(t1,x0) && beval(t2,x0)
@@ -62,6 +62,7 @@ object Interpret {
     !treeBad(If(Less(Const(0),Var()), Var(), Minus(Const(0),Var())))
   }.holds
 
+  @ignore
   def main(args : Array[String]) {
     thereIsGoodTree()
   }

--- a/src/test/resources/regression/verification/newsolvers/valid/InsertionSort.scala
+++ b/src/test/resources/regression/verification/newsolvers/valid/InsertionSort.scala
@@ -34,7 +34,7 @@ object InsertionSort {
     case Nil() => true
     case Cons(x, Nil()) => true
     case Cons(x, Cons(y, ys)) => x <= y && isSorted(Cons(y, ys))
-  }   
+  }
 
   /* Inserting element 'e' into a sorted list 'l' produces a sorted list with
    * the expected content and size */
@@ -43,8 +43,8 @@ object InsertionSort {
     l match {
       case Nil() => Cons(e,Nil())
       case Cons(x,xs) => if (x <= e) Cons(x,sortedIns(e, xs)) else Cons(e, l)
-    } 
-  } ensuring(res => contents(res) == contents(l) ++ Set(e) 
+    }
+  } ensuring(res => contents(res) == contents(l) ++ Set(e)
                     && isSorted(res)
                     && size(res) == size(l) + 1
             )
@@ -54,11 +54,12 @@ object InsertionSort {
   def sort(l: List): List = (l match {
     case Nil() => Nil()
     case Cons(x,xs) => sortedIns(x, sort(xs))
-  }) ensuring(res => contents(res) == contents(l) 
+  }) ensuring(res => contents(res) == contents(l)
                      && isSorted(res)
                      && size(res) == size(l)
              )
 
+  @ignore
   def main(args: Array[String]): Unit = {
     val ls: List = Cons(5, Cons(2, Cons(4, Cons(5, Cons(1, Cons(8,Nil()))))))
 

--- a/src/test/resources/regression/verification/purescala/valid/InsertionSort.scala
+++ b/src/test/resources/regression/verification/purescala/valid/InsertionSort.scala
@@ -34,7 +34,7 @@ object InsertionSort {
     case Nil() => true
     case Cons(x, Nil()) => true
     case Cons(x, Cons(y, ys)) => x <= y && isSorted(Cons(y, ys))
-  }   
+  }
 
   /* Inserting element 'e' into a sorted list 'l' produces a sorted list with
    * the expected content and size */
@@ -43,8 +43,8 @@ object InsertionSort {
     l match {
       case Nil() => Cons(e,Nil())
       case Cons(x,xs) => if (x <= e) Cons(x,sortedIns(e, xs)) else Cons(e, l)
-    } 
-  } ensuring(res => contents(res) == contents(l) ++ Set(e) 
+    }
+  } ensuring(res => contents(res) == contents(l) ++ Set(e)
                     && isSorted(res)
                     && size(res) == size(l) + 1
             )
@@ -54,11 +54,12 @@ object InsertionSort {
   def sort(l: List): List = (l match {
     case Nil() => Nil()
     case Cons(x,xs) => sortedIns(x, sort(xs))
-  }) ensuring(res => contents(res) == contents(l) 
+  }) ensuring(res => contents(res) == contents(l)
                      && isSorted(res)
                      && size(res) == size(l)
              )
 
+  @ignore
   def main(args: Array[String]): Unit = {
     val ls: List = Cons(5, Cons(2, Cons(4, Cons(5, Cons(1, Cons(8,Nil()))))))
 

--- a/src/test/scala/leon/genc/GenCSuite.scala
+++ b/src/test/scala/leon/genc/GenCSuite.scala
@@ -189,8 +189,7 @@ class GenCSuite extends LeonRegressionSuite {
     override def suiteName = "Verification Suite For GenC"
 
     // Add a timeout for the verification
-    override def optionVariants =
-      super.optionVariants map { opts => "--timeout=5" :: opts }
+    override val optionVariants = List(List("--solvers=smt-z3,ground"))
   }
 
   // Run verification suite as a nested suite

--- a/src/test/scala/leon/genc/GenCSuite.scala
+++ b/src/test/scala/leon/genc/GenCSuite.scala
@@ -163,7 +163,7 @@ class GenCSuite extends LeonRegressionSuite {
     mkTest(files, cat)(block)
   }
 
-  protected def testValid(cc: String) = forEachFileIn("valid") { (xCtx, prog) =>
+  protected def testDirectory(cc: String, dir: String) = forEachFileIn(dir) { (xCtx, prog) =>
     val converter = convert(xCtx) _
     val saver     = saveToFile(xCtx) _
     val compiler  = compile(xCtx, cc) _
@@ -173,6 +173,9 @@ class GenCSuite extends LeonRegressionSuite {
 
     pipeline(prog)
   }
+
+  protected def testValid(cc: String) = testDirectory(cc, "valid")
+  protected def testUnverified(cc: String) = testDirectory(cc, "unverified");
 
   protected def testInvalid() = forEachFileIn("invalid") { (xCtx, prog) =>
     intercept[LeonFatalError] {
@@ -199,8 +202,11 @@ class GenCSuite extends LeonRegressionSuite {
   protected def testAll() = {
     // Set C compiler according to the platform we're currently running on
     detectCompiler match {
-      case Some(cc) => testValid(cc)
-      case None     => test("dectecting C compiler") { fail("no C compiler found") }
+      case Some(cc) =>
+        testValid(cc)
+        testUnverified(cc)
+      case None     =>
+        test("dectecting C compiler") { fail("no C compiler found") }
     }
 
     testInvalid()

--- a/src/test/scala/leon/genc/GenCSuite.scala
+++ b/src/test/scala/leon/genc/GenCSuite.scala
@@ -15,6 +15,7 @@ import scala.sys.process._
 
 import org.scalatest.{ Args, Status }
 
+import java.io.ByteArrayInputStream
 import java.nio.file.{ Files, Path }
 
 class GenCSuite extends LeonRegressionSuite {
@@ -100,7 +101,8 @@ class GenCSuite extends LeonRegressionSuite {
     // is printed for some reason.
 
     def testCompiler(cc: String): Boolean = try {
-      val process = s"echo $testCode" #| s"$cc $ccflags -o $testBinary -xc -" #&& s"$testBinary"
+      def input = new ByteArrayInputStream(testCode.getBytes())
+      val process = s"$cc $ccflags -o $testBinary -xc -" #< input #&& s"$testBinary"
       runProcess(process) == 0
     } catch {
       case _: java.lang.RuntimeException => false

--- a/src/test/scala/leon/genc/GenCSuite.scala
+++ b/src/test/scala/leon/genc/GenCSuite.scala
@@ -1,0 +1,194 @@
+/* Copyright 2009-2015 EPFL, Lausanne */
+
+package leon
+package genc
+
+import leon.test.LeonRegressionSuite
+
+import leon.frontends.scalac.ExtractionPhase
+import leon.purescala.Definitions.Program
+import leon.utils.{ PreprocessingPhase, UniqueCounter }
+
+import scala.concurrent._
+import ExecutionContext.Implicits.global
+import scala.sys.process._
+
+import org.scalatest.{ Args, Status }
+
+import java.nio.file.{ Files, Path }
+
+class GenCSuite extends LeonRegressionSuite {
+
+  private val testDir = "regression/genc/"
+  private lazy val tmpDir = Files.createTempDirectory("genc")
+  private val ccflags = "-std=c99 -g -O0"
+  private val maxExecutionTime = 2 // seconds
+
+  private val counter = new UniqueCounter[Unit]
+  counter.nextGlobal // Start with 1
+
+  private case class ExtendedContext(leon: LeonContext, tmpDir: Path, progName: String)
+
+  // Tests are run as follows:
+  // - The classic ExtractionPhase & PreprocessingPhase are run on all input files
+  //   (this way the libraries are evaluated only once)
+  // - A Program is constructed for each input file
+  // - At this point no error should have occurred or something would be wrong
+  //   with the extraction phases
+  // - For each Program P:
+  //   + if P is expected to be convertible to C, then we make sure that:
+  //     * the GenerateCPhase run without trouble,
+  //     * the generated C code compiles using a C99 compiler without error,
+  //     * and that, when run, the exit code is 0
+  //   + if P is expected to be non-convertible to C, then we make sure that:
+  //     * the GenerateCPhase fails
+  private def mkTest(files: List[String], cat: String)(block: (ExtendedContext, Program) => Unit) = {
+    val extraction =
+      ExtractionPhase andThen
+      new PreprocessingPhase(true, true)
+
+    val ctx = createLeonContext(files:_*)
+
+    try {
+      val (_, ast) = extraction.run(ctx, files)
+
+      val programs = {
+        val (user, lib) = ast.units partition { _.isMainUnit }
+        user map ( u => Program(u :: lib) )
+      }
+
+      for { prog <- programs } {
+        val name = prog.units.head.id.name
+        val ctx  = createLeonContext(s"--o=$tmpDir/$name.c")
+        val xCtx = ExtendedContext(ctx, tmpDir, name)
+
+        val displayName = s"$cat/$name.scala"
+        val index       = counter.nextGlobal
+
+        test(f"$index%3d: $displayName") {
+          block(xCtx, prog)
+        }
+      }
+    } catch {
+      case fe: LeonFatalError =>
+        test("Compilation") {
+          fail(ctx, "Unexpected fatal error while setting up tests", fe)
+        }
+    }
+  }
+
+  // Run a process with a timeout and return the status code
+  private def runProcess(pb: ProcessBuilder): Int = runProcess(pb.run)
+  private def runProcess(p: Process): Int = {
+    val f = Future(blocking(p.exitValue()))
+    try {
+      Await.result(f, duration.Duration(maxExecutionTime, "sec"))
+    } catch {
+      case _: TimeoutException =>
+        p.destroy()
+        p.exitValue()
+    }
+  }
+
+  // Determine which C compiler is available
+  private def detectCompiler: Option[String] = {
+    val testCode = "int main() { return 0; }"
+    val testBinary = s"$tmpDir/test"
+
+    // NOTE this code might print error on stderr when a non-existing compiler
+    // is used. It seems that even with a special ProcessLogger the RuntimeException
+    // is printed for some reason.
+
+    def testCompiler(cc: String): Boolean = try {
+      val process = s"echo $testCode" #| s"$cc $ccflags -o $testBinary -xc -" #&& s"$testBinary"
+      runProcess(process) == 0
+    } catch {
+      case _: java.lang.RuntimeException => false
+    }
+
+    val knownCompiler = "cc" :: "clang" :: "gcc" :: "mingw" :: Nil
+    // Note that VS is not in the list as we cannot specify C99 dialect
+
+    knownCompiler find testCompiler
+  }
+
+  private def convert(xCtx: ExtendedContext)(prog: Program) = {
+    try {
+      GenerateCPhase(xCtx.leon, prog)
+    } catch {
+      case fe: LeonFatalError =>
+        fail(xCtx.leon, "Convertion to C unexpectedly failed", fe)
+    }
+  }
+
+  private def saveToFile(xCtx: ExtendedContext)(cprog: CAST.Prog) = {
+    CFileOutputPhase(xCtx.leon, cprog)
+  }
+
+  private def compile(xCtx: ExtendedContext, cc: String)(unused: Unit) = {
+    val basename     = s"${xCtx.tmpDir}/${xCtx.progName}"
+    val sourceFile   = s"$basename.c"
+    val compiledProg = basename
+
+    val process = Process(s"$cc $ccflags $sourceFile -o $compiledProg")
+    val status = runProcess(process)
+
+    assert(status == 0, "Compilation of converted program failed")
+  }
+
+  private def evaluate(xCtx: ExtendedContext)(unused: Unit) = {
+    val compiledProg = s"${xCtx.tmpDir}/${xCtx.progName}"
+
+    // TODO memory limit
+    val process = Process(compiledProg)
+
+    val status = runProcess(process)
+    assert(status == 0, s"Evaluation of converted program failed with status [$status]")
+  }
+
+  private def forEachFileIn(cat: String)(block: (ExtendedContext, Program) => Unit) {
+    val fs = filesInResourceDir(testDir + cat, _.endsWith(".scala")).toList
+
+    fs foreach { file =>
+      assert(file.exists && file.isFile && file.canRead,
+        s"Benchmark ${file.getName} is not a readable file")
+    }
+
+    val files = fs map { _.getPath }
+
+    mkTest(files, cat)(block)
+  }
+
+  protected def testValid(cc: String) = forEachFileIn("valid") { (xCtx, prog) =>
+    val converter = convert(xCtx) _
+    val saver     = saveToFile(xCtx) _
+    val compiler  = compile(xCtx, cc) _
+    val evaluator = evaluate(xCtx) _
+
+    val pipeline  = converter andThen saver andThen compiler andThen evaluator
+
+    pipeline(prog)
+  }
+
+  protected def testInvalid() = forEachFileIn("invalid") { (xCtx, prog) =>
+    intercept[LeonFatalError] {
+      GenerateCPhase(xCtx.leon, prog)
+    }
+  }
+
+  protected def testAll() = {
+    // Set C compiler according to the platform we're currently running on
+    detectCompiler match {
+      case Some(cc) => testValid(cc)
+      case None     => test("dectecting C compiler") { fail("no C compiler found") }
+    }
+
+    testInvalid()
+  }
+
+  override def run(testName: Option[String], args: Args): Status = {
+    testAll()
+    super.run(testName, args)
+  }
+}
+

--- a/src/test/scala/leon/genc/GenCSuite.scala
+++ b/src/test/scala/leon/genc/GenCSuite.scala
@@ -180,20 +180,23 @@ class GenCSuite extends LeonRegressionSuite {
     }
   }
 
-  protected def verifyValidTests() = {
-    class AltVerificationSuite(override val testDir: String) extends XLangVerificationSuite {
-      def run() = testValid() // Test only the valid ones
-    }
+  class AltVerificationSuite(override val testDir: String) extends XLangVerificationSuite {
+    override def testAll() = testValid() // Test only the valid ones
 
+    override def suiteName = "Verification Suite For GenC"
+
+    // Add a timeout for the verification
+    override def optionVariants =
+      super.optionVariants map { opts => "--timeout=5" :: opts }
+  }
+
+  // Run verification suite as a nested suite
+  override def nestedSuites = {
     // Use our test dir and not the one from XLangVerificationSuite
-    val verifier = new AltVerificationSuite(testDir)
-
-    test("verifying test cases") { verifier.run() }
+    scala.collection.immutable.IndexedSeq(new AltVerificationSuite(testDir))
   }
 
   protected def testAll() = {
-    verifyValidTests()
-
     // Set C compiler according to the platform we're currently running on
     detectCompiler match {
       case Some(cc) => testValid(cc)

--- a/src/test/scala/leon/genc/GenCSuite.scala
+++ b/src/test/scala/leon/genc/GenCSuite.scala
@@ -87,7 +87,7 @@ class GenCSuite extends LeonRegressionSuite {
     } catch {
       case _: TimeoutException =>
         p.destroy()
-        p.exitValue()
+        throw LeonFatalError("timeout reached")
     }
   }
 

--- a/src/test/scala/leon/regression/verification/VerificationSuite.scala
+++ b/src/test/scala/leon/regression/verification/VerificationSuite.scala
@@ -19,7 +19,7 @@ import org.scalatest.{Reporter => _, _}
 // This is because we compile all tests from each folder together.
 trait VerificationSuite extends LeonRegressionSuite {
 
-  def optionVariants: List[List[String]]
+  val optionVariants: List[List[String]]
   val testDir: String
 
   val ignored: Seq[String] = Seq()

--- a/src/test/scala/leon/regression/verification/VerificationSuite.scala
+++ b/src/test/scala/leon/regression/verification/VerificationSuite.scala
@@ -19,7 +19,7 @@ import org.scalatest.{Reporter => _, _}
 // This is because we compile all tests from each folder together.
 trait VerificationSuite extends LeonRegressionSuite {
 
-  val optionVariants: List[List[String]]
+  def optionVariants: List[List[String]]
   val testDir: String
 
   val ignored: Seq[String] = Seq()
@@ -81,7 +81,7 @@ trait VerificationSuite extends LeonRegressionSuite {
   private[verification] def forEachFileIn(cat: String)(block: Output => Unit) {
     val fs = filesInResourceDir(testDir + cat, _.endsWith(".scala")).toList
 
-    fs foreach { file => 
+    fs foreach { file =>
       assert(file.exists && file.isFile && file.canRead,
         s"Benchmark ${file.getName} is not a readable file")
     }

--- a/src/test/scala/leon/regression/verification/XLangVerificationSuite.scala
+++ b/src/test/scala/leon/regression/verification/XLangVerificationSuite.scala
@@ -8,7 +8,7 @@ import smtlib.interpreters.Z3Interpreter
 // This is because we compile all tests from each folder together.
 class XLangVerificationSuite extends VerificationSuite {
 
-  def optionVariants: List[List[String]] = {
+  val optionVariants: List[List[String]] = {
     val isZ3Available = try {
       Z3Interpreter.buildDefault.free()
       true
@@ -30,3 +30,4 @@ class XLangVerificationSuite extends VerificationSuite {
   val testDir: String = "regression/verification/xlang/"
   override val desugarXLang = true
 }
+

--- a/src/test/scala/leon/regression/verification/XLangVerificationSuite.scala
+++ b/src/test/scala/leon/regression/verification/XLangVerificationSuite.scala
@@ -8,7 +8,7 @@ import smtlib.interpreters.Z3Interpreter
 // This is because we compile all tests from each folder together.
 class XLangVerificationSuite extends VerificationSuite {
 
-  val optionVariants: List[List[String]] = {
+  def optionVariants: List[List[String]] = {
     val isZ3Available = try {
       Z3Interpreter.buildDefault.free()
       true

--- a/testcases/repair/DaysToYears/DaysToYears.scala
+++ b/testcases/repair/DaysToYears/DaysToYears.scala
@@ -1,10 +1,11 @@
+import leon.annotation._
 import leon.lang._
 
 object DaysToYears {
   val base : Int = 1980
-  
+
   def isLeapYear(y : Int): Boolean = y % 4 == 0
-  
+
   def daysToYears(days : Int): Int = {
     require(days > 0)
     daysToYears1(base, days)._1
@@ -17,16 +18,17 @@ object DaysToYears {
     else if (days > 365 && !isLeapYear(year))
       daysToYears1(year + 1, days - 365)
     else (year, days)
-  } ensuring { res => 
+  } ensuring { res =>
     res._2 <= 366 &&
-    res._2 >  0   && 
+    res._2 >  0   &&
     res._1 >= base &&
-    (((year,days), res) passes { 
+    (((year,days), res) passes {
       case (1980, 366 ) => (1980, 366)
       case (1980, 1000) => (1982, 269)
     })
-  } 
+  }
 
+  @ignore
   def main(args : Array[String]) = {
     println(daysToYears1(base, 10593 ))
     println(daysToYears1(base, 366 ))

--- a/testcases/repair/DaysToYears/DaysToYears1.scala
+++ b/testcases/repair/DaysToYears/DaysToYears1.scala
@@ -1,10 +1,11 @@
+import leon.annotation._
 import leon.lang._
 
 object DaysToYears {
   val base : Int = 1980
-  
+
   def isLeapYear(y : Int): Boolean = y % 4 == 0
-  
+
   def daysToYears(days : Int): Int = {
     require(days > 0)
     daysToYears1(base, days)._1
@@ -17,17 +18,18 @@ object DaysToYears {
     else if (days > 365 && !isLeapYear(year))
       daysToYears1(year, days - 365) // FIXME forgot +1
     else (year, days)
-  } ensuring { res => 
+  } ensuring { res =>
     res._2 <= 366 &&
-    res._2 >  0   && 
+    res._2 >  0   &&
     res._1 >= base &&
-    (((year,days), res) passes { 
+    (((year,days), res) passes {
       case (1999, 14 )  => (1999, 14)
       case (1980, 366)  => (1980, 366)
       case (1981, 366)  => (1982, 1)
     })
-  } 
+  }
 
+  @ignore
   def main(args : Array[String]) = {
     println(daysToYears1(base, 10593 ))
     println(daysToYears1(base, 366 ))

--- a/testcases/repair/DaysToYears/DaysToYears2.scala
+++ b/testcases/repair/DaysToYears/DaysToYears2.scala
@@ -1,10 +1,11 @@
+import leon.annotation._
 import leon.lang._
 
 object DaysToYears {
   val base : Int = 1980
-  
+
   def isLeapYear(y : Int): Boolean = y % 4 == 0
-  
+
   def daysToYears(days : Int): Int = {
     require(days > 0)
     daysToYears1(base, days)._1
@@ -16,17 +17,18 @@ object DaysToYears {
       daysToYears1(year + 1, days - 366) // TODO this branch cannot be solved although it is correct because it depends on the erroneous branch
     else if (days > 365 && !isLeapYear(year))
       daysToYears1(year + 1, days - 365)
-    else (year + 1, days) // FIXME +1 
-  } ensuring { res => 
+    else (year + 1, days) // FIXME +1
+  } ensuring { res =>
     res._2 <= 366 &&
-    res._2 >  0   && 
+    res._2 >  0   &&
     res._1 >= base &&
-    (((year,days), res) passes { 
+    (((year,days), res) passes {
       case (1980, 366 ) => (1980, 366)
       case (1980, 1000) => (1982, 269)
     })
-  } 
+  }
 
+  @ignore
   def main(args : Array[String]) = {
     println(daysToYears1(base, 10593 ))
     println(daysToYears1(base, 366 ))

--- a/testcases/runtime/SquareRoot.scala
+++ b/testcases/runtime/SquareRoot.scala
@@ -1,3 +1,4 @@
+import leon.annotation._
 import leon.lang._
 import leon.lang.synthesis._
 
@@ -23,6 +24,7 @@ object SquareRoot {
     }
   }
 
+  @ignore
   def main(a: Array[String]) {
     isqrt2(42)
   }

--- a/testcases/synthesis/condabd/benchmarks/BatchedQueue/BatchedQueue.scala
+++ b/testcases/synthesis/condabd/benchmarks/BatchedQueue/BatchedQueue.scala
@@ -1,3 +1,4 @@
+import leon.annotation._
 import leon.lang._
 import leon.collection._
 
@@ -50,7 +51,7 @@ object BatchedQueue {
       case Cons(_, xs) => checkf(xs, p.r)
     }
   }
-  //	  
+  //
   //	  def last(p: Queue): Int = {
   //	    require(!isEmpty(p))
   //	    p.r match {
@@ -66,6 +67,7 @@ object BatchedQueue {
           (if (isEmpty(p)) true
           else content(tail(res)) ++ Set(x) == content(tail(res))))
 
+  @ignore
   def main(args: Array[String]): Unit = {
     val pair = Queue(Cons(4, Nil), Cons(3, Nil))
 

--- a/testcases/verification/case-studies/Robot3po.scala
+++ b/testcases/verification/case-studies/Robot3po.scala
@@ -365,7 +365,7 @@ object Robot {
   }
 
   def validState(rs: RobotState)(implicit w: World): Boolean = {
-    
+
     // 6) Sensors have consistent data
     val recentData = rs.ns.validData && rs.hs.validData
 
@@ -509,6 +509,7 @@ object Robot {
   }
 
 
+  @ignore
   def main(a: Array[String]): Unit = {
     val map0 = """|XXXXXXXXX
                   |XR FF   X

--- a/testcases/verification/compilation/Interpreter.scala
+++ b/testcases/verification/compilation/Interpreter.scala
@@ -1,12 +1,13 @@
+import leon.annotation._
 import leon.lang._
 
 object Interpret {
-  abstract class BoolTree 
+  abstract class BoolTree
   case class Eq(t1 : IntTree, t2 : IntTree) extends BoolTree
   case class And(t1 : BoolTree, t2 : BoolTree) extends BoolTree
   case class Not(t : BoolTree) extends BoolTree
 
-  abstract class IntTree 
+  abstract class IntTree
   case class Const(c:Int) extends IntTree
   case class Var(index:Int) extends IntTree
   case class Plus(t1 : IntTree, t2 : IntTree) extends IntTree
@@ -19,7 +20,7 @@ object Interpret {
   }
 
   def beval(t:BoolTree, x0 : Int) : Boolean = {
-    t match {   
+    t match {
       case Less(t1, t2) => ieval(t1,x0) < ieval(t2,x0)
       case Eq(t1, t2) => ieval(t1,x0) == ieval(t2,x0)
       case And(t1, t2) => beval(t1,x0) && beval(t2,x0)
@@ -56,6 +57,7 @@ object Interpret {
     !treeBad(If(Less(Const(0),Var(0)), Var(0), Minus(Const(0),Var(0))))
   } holds
 
+  @ignore
   def main(args : Array[String]) {
     thereIsGoodTree()
   }

--- a/testcases/verification/compilation/SimpInterpret.scala
+++ b/testcases/verification/compilation/SimpInterpret.scala
@@ -1,5 +1,5 @@
 //import scala.collection.immutable.Set
-//import leon.annotation._
+import leon.annotation._
 import leon.lang._
 
 object Interpret {
@@ -61,6 +61,7 @@ object Interpret {
     !treeBad(If(Less(Const(0),Var()), Var(), Minus(Const(0),Var())))
   } holds
 
+  @ignore
   def main(args : Array[String]) {
     thereIsGoodTree()
   }

--- a/testcases/verification/graph/MST/MSTMap.scala
+++ b/testcases/verification/graph/MST/MSTMap.scala
@@ -15,16 +15,16 @@ object MSTMap {
   def mst(g : Graph) : Map[(Int,Int), Int] = {
     require(invariant(g) && isUndirected(g) && isConnected(g) &&
   g.nVertices <= 3)
-    
+
     var uf_map = Map.empty[Int, Int] //map to represent parent
     //relationship to model union find
 
     var spanningTree = Map.empty[(Int,Int), Int]
     var alreadyTested = Map.empty[(Int, Int), Int]
-    
+
     (while(!isConnected(spanningTree, g.nVertices)) {
       val next_edge = getSmallestEdge(g.nVertices, g.edges, alreadyTested)
-      
+
       val p1 = uFind(next_edge._1, uf_map)
       val p2 = uFind(next_edge._2, uf_map)
       if(p1  != p2) {
@@ -45,18 +45,18 @@ object MSTMap {
   // We only verify that the edge set returned corresponds to some
   // spanning tree, but not that it is of minimal weight.
 
-  
+
   // Here, we always take the smallest edge regardless whether it
   // creates a cycle or not,
   // Leon loops
   def mstBogus(g : Graph) : Map[(Int,Int), Int] = {
     require(invariant(g) && isUndirected(g) && isConnected(g) &&
   g.nVertices <= 4)
-    
+
     var edges = g.edges
     var spanningTree = Map.empty[(Int,Int), Int]
     var alreadyTested = Map.empty[(Int, Int), Int]
-    
+
     (while(!isConnected(spanningTree, g.nVertices)) {
       val next_edge = getSmallestEdge(g.nVertices, edges, alreadyTested)
 
@@ -73,13 +73,13 @@ object MSTMap {
     spanningTree
   } ensuring(x => isAcyclic(x, g.nVertices) && isConnected(x, g.nVertices))
 
-  
+
   /*
    -----------------------------------------------------------------------------
    GRAPH FUNCTIONS
    -----------------------------------------------------------------------------
    */
-  
+
 
   def invariant(g : Graph) = {
     def noSelfLoops(i : Int) : Boolean = {
@@ -89,10 +89,10 @@ object MSTMap {
       else
 	noSelfLoops(i+1)
     }
-    
+
     g.nVertices >= 0 && noSelfLoops(0)
   }
-  
+
   /**
    Tests, if g is undirected, that is if for every edge (i,j) there is
    also and edge (j,i)
@@ -108,11 +108,11 @@ object MSTMap {
       var j = 0
       while(j < g.nVertices && res) {
 	res = !edgeSet.isDefinedAt(i,j) || edgeSet.isDefinedAt(j,i)
-	
+
 	 //If weights should considered
 	 if(res && edgeSet.isDefinedAt(i,j))
 	   res = edgeSet(i,j) == edgeSet(j,i)
-	   
+
 	j += 1
       }
       i += 1
@@ -136,11 +136,11 @@ object MSTMap {
      it this function would always return a valid edge, however, this
      property is not easily expressible in Leon.
      */
-    
+
     var i = 0
     val big = 100000000
     var res = (-1,-1,big)
-      
+
       while(i < nVertices) {
 	var j = 0
 	while(j < nVertices) {
@@ -171,7 +171,7 @@ object MSTMap {
      require(g.nVertices >= 0 && isUndirected(g))
      isConnected(g.edges, g.nVertices)
    }
-  
+
   def isConnected(edges : Map[(Int,Int), Int], nVertices : Int) :  Boolean = {
     require(nVertices >= 0)
     val uf = calculateUF(edges, nVertices)._1
@@ -204,7 +204,7 @@ object MSTMap {
   def calculateUF(edgeSet : Map[(Int,Int), Int], nVertices : Int) :
   (Map[Int, Int], Boolean)= {
     require(nVertices >= 0)
-    
+
     var i = 0
     var uf = Map.empty[Int, Int]
     var cycle = false
@@ -223,7 +223,7 @@ object MSTMap {
 
 	    //"remove" twin edge
 	    edges = edges.updated((j,i), -1)
-	  }	   
+	  }
 	}
 	j += 1
       }
@@ -232,7 +232,7 @@ object MSTMap {
 
     (uf, cycle)
   }
-  
+
   /* *************************************
    Union find
    *************************************** */
@@ -246,7 +246,7 @@ object MSTMap {
     // naive union
     val p1 = uFind(e1,s)
     val p2 = uFind(e2, s)
-    
+
     if(p1 != p2)
       //naive union
       s.updated(p1, p2) //only union if theiy are really in different trees
@@ -257,7 +257,8 @@ object MSTMap {
 
   // fsc -d classes -classpath
   // ../../leon-2.0/target/scala-2.9.1-1/classes MST.scala
-  //   scala -classpath classes MST  
+  //   scala -classpath classes MST
+  @ignore
   def main(args: Array[String]) {
     val edges = Map((1,0) -> 10, (0,1) -> 10, (1,2) -> 12, (2,1) ->
   12, (0,2) -> 18, (2,0) -> 18, (3,1) -> 20, (1,3) -> 20)
@@ -267,5 +268,5 @@ object MSTMap {
     println(mst(g)); //works
     println(mstBogus(g)); // crashes because postcondition doensn't hold
   }
-  
+
 }

--- a/testcases/verification/graph/dijkstras/DijkstrasSortedList.scala
+++ b/testcases/verification/graph/dijkstras/DijkstrasSortedList.scala
@@ -11,14 +11,14 @@ object DijkstrasSortedList {
    * Graph representation and algorithms
    **************************************************************************/
   case class Graph(nVertices : Int, edges : Map[(Int,Int), Int])
-  
+
   // Disallow self edges? Not actually important since they can be ignored.
   def invariant(g : Graph) = g.nVertices >= 0
-  
+
   // true if x & y have same number of nodes and y has all x's edges
   def isSubGraph(x : Graph, y : Graph) : Boolean = {
     require(invariant(x) && invariant(y))
-    
+
     var ret : Boolean = (x.nVertices == y.nVertices)
     if (ret){
       var i = 0
@@ -34,11 +34,11 @@ object DijkstrasSortedList {
     }
     ret
   }
-  
+
   // true if every edge has a weight of at least 0
   def nonnegativeWeights(g : Graph) : Boolean = {
     require(invariant(g))
-    
+
     var ret : Boolean = true
     var i = 0
     while(i<g.nVertices) {
@@ -54,20 +54,20 @@ object DijkstrasSortedList {
     }
     ret
   }
-  
+
   // true if b is reachable from a
   def isReachable(g : Graph, a : Int, b : Int) : Boolean = {
     require(invariant(g) && a >= 0 && a < g.nVertices && b >= 0 && b < g.nVertices)
-    
+
     //TODO
     false
   }
-  
-  
+
+
   /***************************************************************************
    * Sorted list representation and algorithims
    **************************************************************************/
-   
+
   /** A list containing node, dist pairs.
    *
    * Sorted by distance, nearest first. Distance must be non-negative. Node
@@ -76,7 +76,7 @@ object DijkstrasSortedList {
   abstract class SortedNDList
   case class ListNode(node : Int, dist : Int, next : SortedNDList) extends SortedNDList
   case class ListEnd() extends SortedNDList
-  
+
   /** List invariant (see description above) */
   @induct
   def sndInvariant(list : SortedNDList) : Boolean = {
@@ -91,18 +91,18 @@ object DijkstrasSortedList {
             false
         case ListEnd() => true //len <= 3
       }
-    
+
     invRec(list/*, Set.empty, 0, 0*/)
   }
-  
+
   /** Look for node in list and remove, if it exists. */
   @induct
   def removeFromList(list : SortedNDList, node : Int) : SortedNDList ={
     // something about this times out
     require(sndInvariant(list))
-    
+
     //println("removeFromList: "+list)
-    
+
     list match  {
       case ListNode(n,d,next) =>
         if (n == node)
@@ -113,7 +113,7 @@ object DijkstrasSortedList {
       case ListEnd() => list
     }
   } ensuring(sndInvariant(_))   // something about this generates an error: is the precondition not checked for _all_ elements or something?
-  
+
   /** Return true if list contains node */
   @induct
   def listContains(list : SortedNDList, node : Int) : Boolean ={
@@ -126,14 +126,14 @@ object DijkstrasSortedList {
       case ListEnd() => false
     }
   }
-  
+
   /** Add a new node to the list, such that list remains sorted by distance.
    * Assume node is not already in list. */
   @induct
   def addSorted(list : SortedNDList, node : Int, dist : Int) : SortedNDList = {
     // something to do with this times out
     require(sndInvariant(list) && !listContains(list, node) && node >= 0 && dist >= 0)
-    
+
     list match {
       case ListNode(n,d,next) =>
         if (d > dist)        // insert here
@@ -144,37 +144,37 @@ object DijkstrasSortedList {
         ListNode(node, dist, list)
     }
   } ensuring (sndInvariant(_))  // something to do with this times out
-  
+
   /** Update node with distance minimum of dist and current value. Add if not
    * in list, and maintain sorted order. */
   @induct
   def updateDistInList(list : SortedNDList, node : Int, dist : Int) : SortedNDList = {
     require(sndInvariant(list) && node >= 0 && dist >= 0)
-    
+
     val listRemoved = removeFromList(list, node)
     addSorted(listRemoved, node, dist)
   } ensuring(sndInvariant(_))
-  
-   
+
+
   /***************************************************************************
    * Dijkstra's algorithm
    **************************************************************************/
-  
+
   def isNodeNotB(list : SortedNDList, b : Int) : Boolean =
     list match {
       case ListNode(n, _, _) => n!=b
       case ListEnd() => false
     }
-  
+
   // common precondition: g is a valid graph and a and b are valid nodes
   def bounds(g : Graph, a : Int, b : Int) : Boolean =
     invariant(g) && 0 <= a && a < g.nVertices && 0 <= b && b < g.nVertices
-  
+
   // find the shortest path from a to b in g, and return its distance
   // return -1 if the two aren't connected
   def shortestPath(g : Graph, a : Int, b : Int) : Int = {
     require(bounds(g,a,b) && nonnegativeWeights(g))
-    
+
     // We should always have at least some node if we haven't reached b (so
     // long as b is in the graph and connected to a).
     @induct
@@ -184,20 +184,20 @@ object DijkstrasSortedList {
        * We should check same invariant at function exit. But there's no point:
        * it's too much for Leon to reason about at once!
        */
-      
+
       list match {
         case ListNode(node, dist, next) if (node==b) =>
           list
         case ListNode(node, dist, next) =>
           var n = 0
           var tail : SortedNDList = next
-          
+
           (while (n < g.nVertices){
             if (n != node && !visited.contains(n) && g.edges.isDefinedAt((node,n)))
               tail = updateDistInList(tail, n, dist+g.edges((node,n)))
             n = n + 1
           }) invariant(sndInvariant(list) && n >= 0 && n <= g.nVertices)
-          
+
           spVisit (tail, visited ++ Set(node))
         case ListEnd() =>
           list
@@ -206,7 +206,7 @@ object DijkstrasSortedList {
       case ListEnd() => !isReachable(g,a,b)
       case ListNode(node,_,_) => node==b
     })
-    
+
     // We start from a, which has distance 0. All other nodes implicitly have
     // infinite distance.
     val startingList : SortedNDList = ListNode(a, 0, ListEnd())
@@ -221,12 +221,13 @@ object DijkstrasSortedList {
         -1
     }
   } ensuring (res => res >= -1 /*(if (isReachable(g,a,b)) res>=0 else res== -1)*/)
-  
+
+  @ignore
   def main(args: Array[String]) {
     val spanningTreeE = Map((0,1) -> 1, (0,2) -> 2, (2,3) -> 5, (0,3) -> 10, (3,2) -> 0)
     val spanningTree = Graph(4, spanningTreeE)
     val singleGraph = Graph(1, Map.empty)
-    
+
     println(spanningTree)
     println("from 0 to 3 (should be 7): "+shortestPath(spanningTree,0,3))
     println("from 3 to 1 (no path): "+shortestPath(spanningTree,3,1))

--- a/testcases/verification/list-algorithms/InsertionSort.scala
+++ b/testcases/verification/list-algorithms/InsertionSort.scala
@@ -51,7 +51,7 @@ object InsertionSort {
     case Nil() => true
     case Cons(x, Nil()) => true
     case Cons(x, Cons(y, ys)) => x <= y && isSorted(Cons(y, ys))
-  }   
+  }
 
   /* Inserting element 'e' into a sorted list 'l' produces a sorted list with
    * the expected content and size */
@@ -60,8 +60,8 @@ object InsertionSort {
     l match {
       case Nil() => Cons(e,Nil())
       case Cons(x,xs) => if (x <= e) Cons(x,sortedIns(e, xs)) else Cons(e, l)
-    } 
-  } ensuring(res => contents(res) == contents(l) ++ Set(e) 
+    }
+  } ensuring(res => contents(res) == contents(l) ++ Set(e)
                     && isSorted(res)
                     && size(res) == size(l) + 1
             )
@@ -73,8 +73,8 @@ object InsertionSort {
     l match {
       case Nil() => Cons(e,Nil())
       case Cons(x,xs) => if (x <= e) Cons(x,buggySortedIns(e, xs)) else Cons(e, l)
-    } 
-  } ensuring(res => contents(res) == contents(l) ++ Set(e) 
+    }
+  } ensuring(res => contents(res) == contents(l) ++ Set(e)
                     && isSorted(res)
                     && size(res) == size(l) + 1
             )
@@ -84,11 +84,12 @@ object InsertionSort {
   def sort(l: List): List = (l match {
     case Nil() => Nil()
     case Cons(x,xs) => sortedIns(x, sort(xs))
-  }) ensuring(res => contents(res) == contents(l) 
+  }) ensuring(res => contents(res) == contents(l)
                      && isSorted(res)
                      && size(res) == size(l)
              )
 
+  @ignore
   def main(args: Array[String]): Unit = {
     val ls: List = Cons(5, Cons(2, Cons(4, Cons(5, Cons(1, Cons(8,Nil()))))))
 

--- a/testcases/verification/list-algorithms/MergeSort.scala
+++ b/testcases/verification/list-algorithms/MergeSort.scala
@@ -1,4 +1,5 @@
 import leon.lang._
+import leon.annotation._
 
 object MergeSort {
   sealed abstract class List
@@ -57,6 +58,7 @@ object MergeSort {
   }) ensuring(res => contents(res) == contents(list) && is_sorted(res))
 
 
+  @ignore
   def main(args: Array[String]): Unit = {
     val ls: List = Cons(5, Cons(2, Cons(4, Cons(5, Cons(1, Cons(8,Nil()))))))
     println(ls)

--- a/testcases/verification/list-algorithms/QuickSort.scala
+++ b/testcases/verification/list-algorithms/QuickSort.scala
@@ -53,7 +53,7 @@ object QuickSort {
     case Nil() => bList
     case _ => rev_append(reverse(aList),bList)
   }) ensuring(content(_) == content(aList) ++ content(bList))
-  
+
   def greater(n:Int,list:List) : List = list match {
     case Nil() => Nil()
     case Cons(x,xs) => if (n < x) Cons(x,greater(n,xs)) else greater(n,xs)
@@ -69,7 +69,7 @@ object QuickSort {
     case Nil() => Nil()
     case Cons(x,xs) => if (n>x) Cons(x,smaller(n,xs)) else smaller(n,xs)
   }
-    
+
   @induct
   def smallerProp(n: Int, list: List): Boolean = (max(smaller(n, list)) match {
     case Some(m) => n > m
@@ -117,6 +117,7 @@ object QuickSort {
     case Cons(x,xs) => append(append(quickSort(smaller(x,xs)),Cons(x,equals(x,xs))),quickSort(greater(x,xs)))
   }) ensuring(res => content(res) == content(list)) // && isSorted(res))
 
+  @ignore
   def main(args: Array[String]): Unit = {
     val ls: List = Cons(5, Cons(2, Cons(4, Cons(5, Cons(1, Cons(8,Nil()))))))
 

--- a/testcases/verification/math/Prime.scala
+++ b/testcases/verification/math/Prime.scala
@@ -1,3 +1,5 @@
+import leon.annotation._
+
 object Prime {
   // an attempt at defining isPrime in PureScala...
 
@@ -36,6 +38,7 @@ object Prime {
   } ensuring(res => !res)
 
   // Just for testing.
+  @ignore
   def main(args : Array[String]) : Unit = {
     def test(n : BigInt) : Unit = {
       println("Is " + n + " prime ? -> " + isPrime(n))

--- a/testcases/verification/xlang/InsertionSort.scala
+++ b/testcases/verification/xlang/InsertionSort.scala
@@ -32,7 +32,7 @@ object InsertionSort {
     case Nil() => true
     case Cons(x, Nil()) => true
     case Cons(x, Cons(y, ys)) => x <= y && isSorted(Cons(y, ys))
-  }   
+  }
   def isReversedSorted(l: List): Boolean = l match {
     case Nil() => true
     case Cons(x, Nil()) => true
@@ -66,8 +66,8 @@ object InsertionSort {
     l match {
       case Nil() => Cons(e,Nil())
       case Cons(x,xs) => if (x <= e) Cons(x,sortedIns(e, xs)) else Cons(e, l)
-    } 
-  } ensuring(res => contents(res) == contents(l) ++ Set(e) 
+    }
+  } ensuring(res => contents(res) == contents(l) ++ Set(e)
                     && isSorted(res)
                     && size(res) == size(l) + 1
             )
@@ -79,8 +79,8 @@ object InsertionSort {
     l match {
       case Nil() => Cons(e,Nil())
       case Cons(x,xs) => if (x <= e) Cons(x,buggySortedIns(e, xs)) else Cons(e, l)
-    } 
-  } ensuring(res => contents(res) == contents(l) ++ Set(e) 
+    }
+  } ensuring(res => contents(res) == contents(l) ++ Set(e)
                     && isSorted(res)
                     && size(res) == size(l) + 1
             )
@@ -90,11 +90,12 @@ object InsertionSort {
   def sort(l: List): List = (l match {
     case Nil() => Nil()
     case Cons(x,xs) => sortedIns(x, sort(xs))
-  }) ensuring(res => contents(res) == contents(l) 
+  }) ensuring(res => contents(res) == contents(l)
                      && isSorted(res)
                      && size(res) == size(l)
              )
 
+  @ignore
   def main(args: Array[String]): Unit = {
     val ls: List = Cons(5, Cons(2, Cons(4, Cons(5, Cons(1, Cons(8,Nil()))))))
 

--- a/testcases/web/demos/008_Tutorial-Robot.scala
+++ b/testcases/web/demos/008_Tutorial-Robot.scala
@@ -365,7 +365,7 @@ object Robot {
   }
 
   def validState(rs: RobotState)(implicit w: World): Boolean = {
-    
+
     // 6) Sensors have consistent data
     val recentData = rs.ns.validData && rs.hs.validData
 
@@ -509,6 +509,7 @@ object Robot {
   }
 
 
+  @ignore
   def main(a: Array[String]): Unit = {
     val map0 = """|XXXXXXXXX
                   |XR FF   X

--- a/testcases/web/verification/03_Insertion_Sort.scala
+++ b/testcases/web/verification/03_Insertion_Sort.scala
@@ -24,7 +24,7 @@ object InsertionSort {
     case Nil => true
     case Cons(x, Nil) => true
     case Cons(x, Cons(y, ys)) => x <= y && isSorted(Cons(y, ys))
-  }   
+  }
 
   /* Inserting element 'e' into a sorted list 'l' produces a sorted list with
    * the expected content and size */
@@ -33,8 +33,8 @@ object InsertionSort {
     l match {
       case Nil => Cons(e,Nil)
       case Cons(x,xs) => if (x <= e) Cons(x,sortedIns(e, xs)) else Cons(e, l)
-    } 
-  } ensuring(res => contents(res) == contents(l) ++ Set(e) 
+    }
+  } ensuring(res => contents(res) == contents(l) ++ Set(e)
                     && isSorted(res)
                     && size(res) == size(l) + 1
             )
@@ -44,8 +44,8 @@ object InsertionSort {
     l match {
       case Nil => Cons(e,Nil)
       case Cons(x,xs) => if (x <= e) Cons(x,buggySortedIns(e, xs)) else Cons(e, l)
-    } 
-  } ensuring(res => contents(res) == contents(l) ++ Set(e) 
+    }
+  } ensuring(res => contents(res) == contents(l) ++ Set(e)
                     && isSorted(res)
                     && size(res) == size(l) + 1
             )
@@ -55,7 +55,7 @@ object InsertionSort {
   def sort(l: List): List = (l match {
     case Nil => Nil
     case Cons(x,xs) => sortedIns(x, sort(xs))
-  }) ensuring(res => contents(res) == contents(l) 
+  }) ensuring(res => contents(res) == contents(l)
                      && isSorted(res)
                      && size(res) == size(l)
              )
@@ -69,6 +69,7 @@ object InsertionSort {
     }
   } ensuring(res => contents(res) == contents(l1) ++ contents(l2) && isSorted(res))
 
+  @ignore
   def main(args: Array[String]): Unit = {
     val ls: List = Cons(5, Cons(2, Cons(4, Cons(5, Cons(1, Cons(8,Nil))))))
 


### PR DESCRIPTION
Hi,

So here is the first version. Let me know if you have any comment. ;-)

This also includes three commits that alter Leon outside of my GenC phase:
 - ~~cb17021b6415f4d17bf4b94de80d13a753c17761~~: No longer automatically ignore main function when extracting AST
 - ~~5b5a006009ec88f1b5619bea1fb2608ebeaeee2e~~: Fix BVNot symbol and add purescala pretty printer support
 - ~~dff11964d134a4bb058022badbf5ed4b48f7f297~~: Fix issue with escaped characters on Windows' path
 - ~~d73ab87fd57bbf6dbb806ebce1ddd5e90d6cdfb5~~: Fix documentation and C conversion of BVAShiftRight and BVLShiftRight

The regression tests were tested on OS X and Windows. They work nicely (TM) except for one cosmetic thing that I could not solve: when looking for a C compiler on the system, known compilers will be tested until one that is installed is found. However, for each tested compiler that is not available, some `IOException/RuntimeException` are printed to the console. I couldn't find a way to catch those exceptions with scala's Process API.