### PR TITLE
"ask" and "byExample" constructs

### DIFF
--- a/library/lang/package.scala
+++ b/library/lang/package.scala
@@ -20,16 +20,7 @@ package object lang {
       if (underlying) that else true
     }
   }
-
-  implicit class SpecsDecorations[A](val underlying: A) {
-    @inline
-    def computes(target: A) = {
-      underlying
-    } ensuring {
-      res => res == target
-    }
-  }
-
+  
   @ignore def forall[A](p: A => Boolean): Boolean = sys.error("Can't execute quantified proposition")
   @ignore def forall[A,B](p: (A,B) => Boolean): Boolean = sys.error("Can't execute quantified proposition")
   @ignore def forall[A,B,C](p: (A,B,C) => Boolean): Boolean = sys.error("Can't execute quantified proposition")
@@ -55,6 +46,27 @@ package object lang {
     val (in, out) = io
     def passes(tests : A => B ) : Boolean =
       try { tests(in) == out } catch { case _ : MatchError => true }
+  }
+  
+  @ignore
+  def byExample[A, B](in: A, out: B): Boolean = {
+    sys.error("Can't execute by example proposition")
+  }
+  
+  implicit class SpecsDecorations[A](val underlying: A) {
+    @ignore
+    def computes(target: A) = {
+      underlying
+    } ensuring {
+      res => res == target
+    }
+    
+    @ignore // Programming by example: ???[String] ask input
+    def ask[I](input : I) = {
+      underlying
+    } ensuring {
+      (res: A) => byExample(input, res)
+    }
   }
 
   @ignore

--- a/src/main/scala/leon/frontends/scalac/ASTExtractors.scala
+++ b/src/main/scala/leon/frontends/scalac/ASTExtractors.scala
@@ -210,6 +210,37 @@ trait ASTExtractors {
         case _ => None
       }
     }
+    
+    
+    /** Matches the `A computes B` expression at the end of any expression A, and returns (A, B).*/
+    object ExComputesExpression {
+      def unapply(tree: Apply) : Option[(Tree, Tree)] = tree match {
+        case Apply(Select(
+          Apply(TypeApply(ExSelected("leon", "lang", "package", "SpecsDecorations"), List(_)), realExpr :: Nil),
+          ExNamed("computes")), expected::Nil)
+         => Some((realExpr, expected))
+        case _ => None
+       }
+    }
+    
+    /** Matches the `O ask I` expression at the end of any expression O, and returns (I, O).*/
+    object ExAskExpression {
+      def unapply(tree: Apply) : Option[(Tree, Tree)] = tree match {
+        case Apply(TypeApply(Select(
+          Apply(TypeApply(ExSelected("leon", "lang", "package", "SpecsDecorations"), List(_)), output :: Nil),
+          ExNamed("ask")), List(_)), input::Nil)
+         => Some((input, output))
+        case _ => None
+       }
+    }
+    
+    object ExByExampleExpression {
+      def unapply(tree: Apply) : Option[(Tree, Tree)] = tree match {
+        case Apply(TypeApply(ExSelected("leon", "lang", "package", "byExample"), List(_, _)), input :: res_output :: Nil)
+         => Some((input, res_output))
+        case _ => None
+       }
+    }
  
     /** Extracts the `(input, output) passes { case In => Out ...}` and returns (input, output, list of case classes) */
     object ExPasses { 

--- a/src/main/scala/leon/purescala/PrettyPrinter.scala
+++ b/src/main/scala/leon/purescala/PrettyPrinter.scala
@@ -114,11 +114,17 @@ class PrettyPrinter(opts: PrinterOptions,
             |}"""
 
       case p@Passes(in, out, tests) =>
-        optP {
-          p"""|($in, $out) passes {
-              |  ${nary(tests, "\n")}
-              |}"""
+        tests match {
+          case Seq(MatchCase(_, Some(BooleanLiteral(false)), NoTree(_))) =>
+            p"""|byExample($in, $out)"""
+          case _ =>
+            optP {
+              p"""|($in, $out) passes {
+                  |  ${nary(tests, "\n")}
+                  |}"""
+            }
         }
+        
 
       case c @ WithOracle(vars, pred) =>
         p"""|withOracle { (${typed(vars)}) =>

--- a/src/main/scala/leon/synthesis/ConversionPhase.scala
+++ b/src/main/scala/leon/synthesis/ConversionPhase.scala
@@ -99,7 +99,7 @@ object ConversionPhase extends UnitPhase[Program] {
     (pre ++ post).foreach {
       preTraversal{
         case h : Hole =>
-          ctx.reporter.error(s"Holes are not supported in pre- or postconditions. @ ${h.getPos}")
+          ctx.reporter.error(s"Holes like $h are not supported in pre- or postconditions. @ ${h.getPos}")
         case wo: WithOracle =>
           ctx.reporter.error(s"WithOracle expressions are not supported in pre- or postconditions: ${wo.asString(ctx)} @ ${wo.getPos}")
         case _ =>

--- a/src/main/scala/leon/synthesis/disambiguation/ExamplesAdder.scala
+++ b/src/main/scala/leon/synthesis/disambiguation/ExamplesAdder.scala
@@ -51,8 +51,10 @@ class ExamplesAdder(ctx0: LeonContext, program: Program) {
     addToFunDef(fd, Seq((newIn, newOut)))
   }
   
+  private def filterCases(cases: Seq[MatchCase]) = cases.filter(c => c.optGuard != Some(BooleanLiteral(false)))
+  
   /** Adds the given input/output examples to the function definitions */
-  def addToFunDef(fd: FunDef, examples: Seq[(Expr, Expr)]) = {
+  def addToFunDef(fd: FunDef, examples: Seq[(Expr, Expr)]): Unit = {
     val params = if(_removeFunctionParameters) fd.params.filter(x => !x.getType.isInstanceOf[FunctionType]) else fd.params
     val inputVariables = tupleWrap(params.map(p => Variable(p.id): Expr))
     val newCases = examples.map{ case (in, out) => exampleToCase(in, out) }
@@ -71,7 +73,7 @@ class ExamplesAdder(ctx0: LeonContext, program: Program) {
               } else {
                 val newPasses = exprs(i) match {
                   case Passes(in, out, cases) =>
-                    Passes(in, out, (cases ++ newCases).distinct )
+                    Passes(in, out, (filterCases(cases) ++ newCases).distinct )
                   case _ => ???
                 }
                 val newPost = and(exprs.updated(i, newPasses) : _*)

--- a/testcases/stringrender/ModularRender.scala
+++ b/testcases/stringrender/ModularRender.scala
@@ -31,12 +31,6 @@ object ModularRender {
   case class Configuration(flags: List[Boolean])
 
   // We want to write Config:[Up,Down,Up....]
-  def ConfigToString(config : Configuration): String =  {
-    ???
-  } ensuring {
-    (res : String) => (config, res) passes {
-      case _ if false =>
-        ""
-    }
-  }
+  def ConfigToString(config : Configuration): String = 
+    ???[String] ask config
 }

--- a/testcases/stringrender/SymbolGrammarRender.scala
+++ b/testcases/stringrender/SymbolGrammarRender.scala
@@ -49,12 +49,6 @@ object GrammarRender {
     }
   }
   
-  def grammarToString(p : Grammar): String =  {
-    ???[String]
-  } ensuring {
-    (res : String) => (p, res) passes {
-      case _ if false =>
-        ""
-    }
-  }
+  def grammarToString(p : Grammar): String = 
+    ???[String] ask p
 }

--- a/testcases/web/synthesis/26_Modular_Render.scala
+++ b/testcases/web/synthesis/26_Modular_Render.scala
@@ -11,16 +11,13 @@ import leon.collection.ListOps._
 import leon.lang.synthesis._
 
 object ModularRender {
-  def customToString[T](l : List[T], f : (T) => String): String =  {
-    ???
-  } ensuring {
-    (res : String) => (l, res) passes {
-      case _ if false => ""
-    }
-  }
   
   def booleanToString(b: Boolean) = if(b) "Up" else "Down"
+
   def intToString(b: BigInt) = b.toString
+  
+  def customToString[T](l : List[T], f : (T) => String): String =
+    ???[String] ask l
   
   case class Configuration(flags: List[Boolean], strokes: List[BigInt])
 
@@ -28,14 +25,8 @@ object ModularRender {
   // Solution:
   //   [Up, Down,  Up....]
   //   [1, 2, 5, ...]
-  def ConfigToString(config : Configuration): String =  {
-    ???
-  } ensuring {
-    (res : String) => (config, res) passes {
-      case _ if false =>
-        ""
-    }
-  }
+  def ConfigToString(config : Configuration): String =
+    ???[String] ask config
   
   /** Wrong lemma for demonstration */
   def configurationsAreSimple(c: Configuration) =


### PR DESCRIPTION
In short, you can now write the two equivalent formats 

```scala
def toSynthesize(input: List[Int]) = ???[String] ask input

def toSynthesize(input: List[Int]) = ???[String] ensuring {
  (res: String) => byExample(input, res)
}
```

and it will trigger a synthesis problem for `toSynthesize` but will only use by example technologies.
Actually it is rewritten to:

```scala
def toSynthesize(input: List[Int]) = ???[String] ensuring {
  (res: String) => (input, res) passes {
    case _ if false => (_: String)
  }
}
```

which would normally not compile but the pretty printer redisplays it using the construct `byExample`
