### PR TITLE
Code Coverage

### DIFF
--- a/library/theories/String.scala
+++ b/library/theories/String.scala
@@ -36,7 +36,8 @@ object String {
   def fromChar(i: Char): String = {
     StringCons(i, StringNil())
   }
-  
+
+  @isabelle.noBody()
   def fromBigInt(i: BigInt): String =
     if(i < 0) StringCons('-', fromBigInt(-i))
     else if(i == BigInt(0)) StringCons('0', StringNil())
@@ -51,6 +52,7 @@ object String {
     else if(i == BigInt(9)) StringCons('9', StringNil())   
     else fromBigInt(i / 10).concat(fromBigInt(i % 10))
 
+  @isabelle.noBody()
   def fromInt(i: Int): String = i match {
     case -2147483648 => StringCons('-', StringCons('2', fromInt(147483648)))
     case i  if i < 0 => StringCons('-', fromInt(-i))

--- a/library/theories/String.scala
+++ b/library/theories/String.scala
@@ -30,3 +30,45 @@ sealed abstract class String {
 
 case class StringCons(head: Char, tail: String) extends String
 case class StringNil() extends String
+
+@library
+object String {
+  def fromChar(i: Char): String = {
+    StringCons(i, StringNil())
+  }
+  
+  def fromBigInt(i: BigInt): String =
+    if(i < 0) StringCons('-', fromBigInt(-i))
+    else if(i == BigInt(0)) StringCons('0', StringNil())
+    else if(i == BigInt(1)) StringCons('1', StringNil())
+    else if(i == BigInt(2)) StringCons('2', StringNil())
+    else if(i == BigInt(3)) StringCons('3', StringNil())
+    else if(i == BigInt(4)) StringCons('4', StringNil())
+    else if(i == BigInt(5)) StringCons('5', StringNil())
+    else if(i == BigInt(6)) StringCons('6', StringNil())
+    else if(i == BigInt(7)) StringCons('7', StringNil())
+    else if(i == BigInt(8)) StringCons('8', StringNil())
+    else if(i == BigInt(9)) StringCons('9', StringNil())   
+    else fromBigInt(i / 10).concat(fromBigInt(i % 10))
+
+  def fromInt(i: Int): String = i match {
+    case -2147483648 => StringCons('-', StringCons('2', fromInt(147483648)))
+    case i  if i < 0 => StringCons('-', fromInt(-i))
+    case 0 => StringCons('0', StringNil())
+    case 1 => StringCons('1', StringNil())
+    case 2 => StringCons('2', StringNil())
+    case 3 => StringCons('3', StringNil())
+    case 4 => StringCons('4', StringNil())
+    case 5 => StringCons('5', StringNil())
+    case 6 => StringCons('6', StringNil())
+    case 7 => StringCons('7', StringNil())
+    case 8 => StringCons('8', StringNil())
+    case 9 => StringCons('9', StringNil())
+    case i => fromInt(i / 10).concat(fromInt(i % 10))
+  }
+  
+  def fromBoolean(b: Boolean): String = {
+    if(b) StringCons('t', StringCons('r', StringCons('u', StringCons('e', StringNil()))))
+    else StringCons('f', StringCons('a', StringCons('l', StringCons('s', StringCons('e', StringNil())))))
+  }
+}

--- a/src/main/scala/leon/purescala/Constructors.scala
+++ b/src/main/scala/leon/purescala/Constructors.scala
@@ -61,7 +61,7 @@ object Constructors {
     else bd
   }
 
-  /** $encodingof ``val (id1, id2, ...) = e; bd``, and returns `bd` if the identifiers are not bound in `bd`.
+  /** $encodingof ``val (...binders...) = value; body`` which is translated to  ``value match { case (...binders...) => body }``, and returns `body` if the identifiers are not bound in `body`.
     * @see [[purescala.Expressions.Let]]
     */
   def letTuple(binders: Seq[Identifier], value: Expr, body: Expr) = binders match {
@@ -72,7 +72,7 @@ object Constructors {
     case xs =>
       require(
         value.getType.isInstanceOf[TupleType],
-        s"The definition value in LetTuple must be of some tuple type; yet we got [${value.getType}]. In expr: \n$this"
+        s"The definition value in LetTuple must be of some tuple type; yet we got [${value.getType}]. In expr: \n$value"
       )
 
       Extractors.LetPattern(TuplePattern(None,binders map { b => WildcardPattern(Some(b)) }), value, body)

--- a/src/main/scala/leon/purescala/DefOps.scala
+++ b/src/main/scala/leon/purescala/DefOps.scala
@@ -318,14 +318,23 @@ object DefOps {
     val transformer = new DefinitionTransformer(idMap, fdMap, cdMap) {
       override def transformExpr(expr: Expr)(implicit bindings: Map[Identifier, Identifier]): Option[Expr] = expr match {
         case fi @ FunctionInvocation(TypedFunDef(fd, tps), args) =>
-          fiMapF(fi, transform(fd))
+          val transformFd = transform(fd)
+          if(transformFd != fd)
+            fiMapF(fi, transformFd)
+          else
+            None
           //val nfi = fiMapF(fi, transform(fd)) getOrElse expr
           //Some(super.transform(nfi))
         case cc @ CaseClass(cct, args) =>
-          ciMapF(cc, transform(cct).asInstanceOf[CaseClassType])
+          val transformCct = transform(cct).asInstanceOf[CaseClassType]
+          if(transformCct != cct)
+            ciMapF(cc, transformCct)
+          else
+            None
           //val ncc = ciMapF(cc, transform(cct).asInstanceOf[CaseClassType]) getOrElse expr
           //Some(super.transform(ncc))
-        case _ => None
+        case _ =>
+          None
       }
 
       override def transformFunDef(fd: FunDef): Option[FunDef] = fdMapF(fd)

--- a/src/main/scala/leon/purescala/DefOps.scala
+++ b/src/main/scala/leon/purescala/DefOps.scala
@@ -97,17 +97,17 @@ object DefOps {
   }
 
   private def stripPrefix(off: List[String], from: List[String]): List[String] = {
-    val commonPrefix = (off zip from).takeWhile(p => p._1 == p._2)
+      val commonPrefix = (off zip from).takeWhile(p => p._1 == p._2)
 
-    val res = off.drop(commonPrefix.size)
+      val res = off.drop(commonPrefix.size)
 
-    if (res.isEmpty) {
-      if (off.isEmpty) List()
-      else List(off.last)
-    } else {
-      res
+      if (res.isEmpty) {
+        if (off.isEmpty) List()
+        else List(off.last)
+      } else {
+        res
+      }
     }
-  }
   
   def simplifyPath(namesOf: List[String], from: Definition, useUniqueIds: Boolean)(implicit pgm: Program) = {
     val pathFrom = pathFromRoot(from).dropWhile(_.isInstanceOf[Program])
@@ -356,8 +356,9 @@ object DefOps {
                                  fiMapF: (FunctionInvocation, FunDef) => Option[Expr] = defaultFiMap)
                                  : (Program, Map[Identifier, Identifier], Map[FunDef, FunDef], Map[ClassDef, ClassDef]) = {
     replaceDefs(p)(fdMapF, cd => None, fiMapF)
-  }
+      }
 
+  /** Replaces all function calls by an expression depending on the previous function invocation and the new mapped function */
   def replaceFunCalls(e: Expr, fdMapF: FunDef => FunDef, fiMapF: (FunctionInvocation, FunDef) => Option[Expr] = defaultFiMap): Expr = {
     preMap {
       case me @ MatchExpr(scrut, cases) =>
@@ -606,9 +607,9 @@ object DefOps {
         case AsInstanceOf(e, ct) => Some(AsInstanceOf(e, tpMap(ct)))
         case MatchExpr(scrut, cases) => 
           Some(MatchExpr(scrut, cases.map{ 
-            case MatchCase(pattern, optGuard, rhs) =>
-              MatchCase(replaceClassDefUse(pattern), optGuard, rhs)
-          }))
+              case MatchCase(pattern, optGuard, rhs) =>
+                MatchCase(replaceClassDefUse(pattern), optGuard, rhs)
+            }))
         case fi @ FunctionInvocation(TypedFunDef(fd, tps), args) =>
           defaultFiMap(fi, fdMap(fd)).map(_.setPos(fi))
         case _ =>
@@ -662,7 +663,7 @@ object DefOps {
       p.definedFunctions.filter(f => f.id.name == after.id.name).map(fd => fd.id.name + " : " + fd) match {
         case Nil => 
         case e => println("Did you mean " + e)
-      }
+    }
       println(Thread.currentThread().getStackTrace.map(_.toString).take(10).mkString("\n"))
     }
 

--- a/src/main/scala/leon/solvers/theories/StringEncoder.scala
+++ b/src/main/scala/leon/solvers/theories/StringEncoder.scala
@@ -22,6 +22,12 @@ class StringEncoder(ctx: LeonContext, p: Program) extends TheoryEncoder {
   val Drop   = p.library.lookupUnique[FunDef]("leon.theories.String.drop").typed
   val Slice  = p.library.lookupUnique[FunDef]("leon.theories.String.slice").typed
   val Concat = p.library.lookupUnique[FunDef]("leon.theories.String.concat").typed
+  
+  val FromInt      = p.library.lookupUnique[FunDef]("leon.theories.String.fromInt").typed
+  val FromChar     = p.library.lookupUnique[FunDef]("leon.theories.String.fromChar").typed
+  val FromBoolean  = p.library.lookupUnique[FunDef]("leon.theories.String.fromBoolean").typed
+  val FromBigInt   = p.library.lookupUnique[FunDef]("leon.theories.String.fromBigInt").typed
+  
 
   private val stringBijection = new Bijection[String, Expr]()
   
@@ -48,6 +54,14 @@ class StringEncoder(ctx: LeonContext, p: Program) extends TheoryEncoder {
         Some(FunctionInvocation(Take, Seq(FunctionInvocation(Drop, Seq(transform(a), transform(start))), transform(length))).copiedFrom(e))
       case SubString(a, start, end)  => 
         Some(FunctionInvocation(Slice, Seq(transform(a), transform(start), transform(end))).copiedFrom(e))
+      case Int32ToString(a) => 
+        Some(FunctionInvocation(FromInt, Seq(transform(a))).copiedFrom(e))
+      case IntegerToString(a) =>
+        Some(FunctionInvocation(FromBigInt, Seq(transform(a))).copiedFrom(e))
+      case CharToString(a) =>
+        Some(FunctionInvocation(FromChar, Seq(transform(a))).copiedFrom(e))
+      case BooleanToString(a) =>
+        Some(FunctionInvocation(FromBoolean, Seq(transform(a))).copiedFrom(e))
       case _ => None
     }
 
@@ -85,6 +99,14 @@ class StringEncoder(ctx: LeonContext, p: Program) extends TheoryEncoder {
       case FunctionInvocation(Drop, Seq(a, count)) =>
         val ra = transform(a)
         Some(SubString(ra, transform(count), StringLength(ra)).copiedFrom(e))
+      case FunctionInvocation(FromInt, Seq(a)) =>
+        Some(Int32ToString(transform(a)).copiedFrom(e))
+      case FunctionInvocation(FromBigInt, Seq(a)) =>
+        Some(IntegerToString(transform(a)).copiedFrom(e))
+      case FunctionInvocation(FromChar, Seq(a)) =>
+        Some(CharToString(transform(a)).copiedFrom(e))
+      case FunctionInvocation(FromBoolean, Seq(a)) =>
+        Some(BooleanToString(transform(a)).copiedFrom(e))
       case _ => None
     }
 

--- a/src/main/scala/leon/synthesis/disambiguation/InputCoverage.scala
+++ b/src/main/scala/leon/synthesis/disambiguation/InputCoverage.scala
@@ -1,0 +1,99 @@
+package leon
+package synthesis.disambiguation
+
+import synthesis.RuleClosed
+import synthesis.Solution
+import evaluators.DefaultEvaluator
+import purescala.Expressions._
+import purescala.ExprOps
+import purescala.Constructors._
+import purescala.Extractors._
+import purescala.Types.{TypeTree, TupleType, BooleanType}
+import purescala.Common.Identifier
+import purescala.Definitions.{FunDef, Program}
+import purescala.DefOps
+import grammars.ValueGrammar
+import bonsai.enumerators.MemoizedEnumerator
+import solvers.Model
+import solvers.ModelBuilder
+import scala.collection.mutable.ListBuffer
+
+import leon.LeonContext
+
+/**
+ * @author Mikael
+ * If possible, synthesizes a set of inputs for the function so that they cover all parts of the function.
+ * 
+ * @param fds The set of functions to cover
+ * @param fd The calling function
+ */
+class InputCoverage(fd: FunDef, fds: Set[FunDef])(implicit c: LeonContext, p: Program) {
+  var numToCoverForEachExample: Int = 1
+  
+  /** The number of expressions is the same as the number of arguments. */
+  def result(): Stream[Seq[Expr]] = {
+    /* Algorithm:
+     * 1) Consider only match/case and if/else statements.
+     * def f(x: Int, z: Boolean): Int =
+     *   x match {
+     *     case 0 | 1 => 1
+     *     case _ =>
+     *       if(z) x*f(x-1,!z)
+     *       else f(x-1,!z)+f(x-2,!z)
+     *   } 
+     * 2) In innermost branches, replace each result by (result, bi) where bi is a boolean described later.
+     * def f(x: Int, z: Boolean): (Int, Boolean) =
+     *   x match {
+     *     case 0 | 1 => (1, b1)
+     *     case _ =>
+     *       if(z) (x*f(x-1,!z), b2)
+     *       else (f(x-1,!z)+f(x-2,!z), b3)
+     *   } 
+     * 3) If the function is recursive, recover the previous values and left-OR them with the returning bi.
+     * def f(x: Int, z: Boolean): (Int, Boolean) =
+     *   x match {
+     *     case 0 | 1 => (1, b1)
+     *     case _ =>
+     *       if(z) {
+     *         val (r, bf) = f(x-1,!z)
+     *         (x*r, b2 || bf)}
+     *       else {
+     *         val (r, bf) = f(x-1,!z)
+     *         val (r2, bf2) = f(x-2,!z)
+     *         (r+r2, b3 || bf || bf2)
+     *       }
+     *   } 
+     * 4) Add the post-condition
+     *   ensuring { res => !res._2 }
+     * 5) Let B be the set of bi.
+     *    For each b in B
+     *      Set all b' in B to false except b to true
+     *      Find a counter-example.
+     *      yield  it in the stream.
+     */
+    
+    /* Change all return types to accommodate the new covering boolean */
+    val changeReturnTypes = { (p: Program) =>
+        val (program, idMap, fdMap, cdMap) = DefOps.replaceFunDefs(p)({
+          (f: FunDef) =>
+            if((fds contains f) || f == fd) {
+              Some(f.duplicate(returnType = TupleType(Seq(f.returnType, BooleanType))))
+            } else
+              None
+        }, {
+          (fi: FunctionInvocation, newFd: FunDef) =>
+            Some(TupleSelect(FunctionInvocation(newFd.typed, fi.args), 1))
+        })
+        (program, fdMap(fd), fds.map(fdMap))
+    }
+    val addNewReturnVariables = { (p: Program, fd: FunDef, fds: Set[FunDef]) => 
+      
+    }
+    
+    (changeReturnTypes andThen
+     addNewReturnVariables.tupled)(p)
+    
+    
+    ???
+  }
+}

--- a/src/main/scala/leon/synthesis/disambiguation/InputCoverage.scala
+++ b/src/main/scala/leon/synthesis/disambiguation/InputCoverage.scala
@@ -32,77 +32,103 @@ class InputCoverage(fd: FunDef, fds: Set[FunDef])(implicit c: LeonContext, p: Pr
   
   /** If the sub-branches contain identifiers, it returns them unchanged.
       Else it creates a new boolean indicating this branch. */
-  def wrapBranch(e: (Expr, Seq[Identifier])): (Expr, Seq[Identifier]) = {
-    if(e._2.isEmpty) {
-      val b = FreshIdentifier("l" + e._1.getPos.line + "c" + e._1.getPos.col, BooleanType)
-      (tupleWrap(Seq(e._1, Variable(b))), Seq(b))
-    } else e // No need to introduce a new boolean since if one of the child booleans is true, then this IfExpr has been called.
+  def wrapBranch(e: (Expr, Option[Seq[Identifier]])): (Expr, Option[Seq[Identifier]]) = e._2 match {
+    case None =>
+      val b = FreshIdentifier("l" + Math.abs(e._1.getPos.line) + "c" + Math.abs(e._1.getPos.col), BooleanType)
+      (tupleWrap(Seq(e._1, Variable(b))), Some(Seq(b)))
+    case Some(Seq()) =>
+      val b = FreshIdentifier("l" + Math.abs(e._1.getPos.line) + "c" + Math.abs(e._1.getPos.col), BooleanType)
+      
+      def putInLastBody(e: Expr): Expr = e match {
+        case Tuple(Seq(v, prev_b)) => Tuple(Seq(v, or(prev_b, b.toVariable))).copiedFrom(e)
+        case LetTuple(binders, value, body) => letTuple(binders, value, putInLastBody(body)).copiedFrom(e)
+        case MatchExpr(scrut, Seq(MatchCase(TuplePattern(optId, binders), None, rhs))) => 
+          MatchExpr(scrut, Seq(MatchCase(TuplePattern(optId, binders), None, putInLastBody(rhs)))).copiedFrom(e)
+        case _ => throw new Exception(s"Unexpected branching case: $e")
+        
+      }
+      (putInLastBody(e._1), Some(Seq(b)))
+    case _ =>
+      // No need to introduce a new boolean since if one of the child booleans is true, then this IfExpr has been called.
+      e
   }
   
   def hasConditionals(e: Expr) = {
     ExprOps.exists{ case i:IfExpr => true case m: MatchExpr => true case f: FunctionInvocation => true case _ => false}(e)
   }
   
+  def merge(a: Option[Seq[Identifier]], b: Option[Seq[Identifier]]) = {
+    (a, b) match {
+      case (None, None) => None
+      case (a, None) => a
+      case (None, b) => b
+      case (Some(a), Some(b)) => Some(a ++ b)
+    }
+  }
+  
   /** For each branch in the expression, adds a boolean variable such that the new type of the expression is (previousType, Boolean)
    *  If no variable is output, then the type of the expression is not changed.
-    * Returns the list of boolean variables which appear in the expression */
+    * If the expression is augmented with a boolean, returns the list of boolean variables which appear in the expression */
   // All functions now return a boolean along with their original return type.
-  def markBranches(e: Expr): (Expr, Seq[Identifier]) =
-    if(!hasConditionals(e)) (e, Seq()) else e match {
+  def markBranches(e: Expr): (Expr, Option[Seq[Identifier]]) =
+    if(!hasConditionals(e)) (e, None) else e match {
     case IfExpr(cond, thenn, elze) =>
       val (c1, cv1) = markBranches(cond)
       val (t1, tv1) = wrapBranch(markBranches(thenn))
       val (e1, ev1) = wrapBranch(markBranches(elze))
-      if(cv1.isEmpty) {
-        (IfExpr(c1, t1, e1).copiedFrom(e), tv1 ++ ev1)
-      } else {
-        val arg_id = FreshIdentifier("arg", BooleanType)
-        val arg_b = FreshIdentifier("b", BooleanType)
-        (letTuple(Seq(arg_id, arg_b), c1, IfExpr(Variable(arg_id), t1, e1).copiedFrom(e)), cv1 ++ tv1 ++ ev1)
+      cv1 match {
+        case None =>
+          (IfExpr(c1, t1, e1).copiedFrom(e), merge(tv1, ev1))
+        case cv1 =>
+          val arg_id = FreshIdentifier("arg", BooleanType)
+          val arg_b = FreshIdentifier("bc", BooleanType)
+          (letTuple(Seq(arg_id, arg_b), c1, IfExpr(Variable(arg_id), t1, e1).copiedFrom(e)).copiedFrom(e), merge(merge(cv1, tv1), ev1))
       }
     case MatchExpr(scrut, cases) =>
       val (c1, cv1) = markBranches(scrut)
-      val (new_cases, variables) = (cases map { case MatchCase(pattern, opt, rhs) =>
+      val (new_cases, variables) = (cases map { case m@MatchCase(pattern, opt, rhs) =>
         val (rhs_new, ids) = wrapBranch(markBranches(rhs))
-        (MatchCase(pattern, opt, rhs_new), ids)
+        (MatchCase(pattern, opt, rhs_new).copiedFrom(m), ids)
       }).unzip // TODO: Check for unapply with function pattern ?
-      (MatchExpr(c1, new_cases).copiedFrom(e), variables.flatten)
+      (MatchExpr(c1, new_cases).copiedFrom(e), variables.fold(None)(merge))
     case Operator(lhsrhs, builder) =>
       // The exprBuilder adds variable definitions needed to compute the arguments.
-      val (exprBuilder, children, ids) = (((e: Expr) => e, List[Expr](), ListBuffer[Identifier]()) /: lhsrhs) {
-        case ((exprBuilder, children, ids), arg) =>
+      val (exprBuilder, children, tmpIds, ids) = (((e: Expr) => e, ListBuffer[Expr](), ListBuffer[Identifier](), None: Option[Seq[Identifier]]) /: lhsrhs) {
+        case ((exprBuilder, children, tmpIds, ids), arg) =>
           val (arg1, argv1) = markBranches(arg)
-          if(argv1.nonEmpty) {
+          if(argv1.nonEmpty || isNewFunCall(arg1)) {
             val arg_id = FreshIdentifier("arg", arg.getType)
-            val arg_b = FreshIdentifier("b", BooleanType)
-            val f = (body: Expr) => letTuple(Seq(arg_id, arg_b), arg1, body)
-            (exprBuilder andThen f, Variable(arg_id)::children, ids ++= argv1)
+            val arg_b = FreshIdentifier("ba", BooleanType)
+            val f = (body: Expr) => letTuple(Seq(arg_id, arg_b), arg1, body).copiedFrom(body)
+            (exprBuilder andThen f, children += Variable(arg_id), tmpIds += arg_b, merge(ids, argv1))
           } else {
-            (exprBuilder, arg::children, ids)
+            (exprBuilder, children += arg, tmpIds, ids)
           }
       }
       e match {
-        case FunctionInvocation(TypedFunDef(fd, targs), args) if fds(fd) =>
+        case FunctionInvocation(tfd@TypedFunDef(fd, targs), args) if fds(fd) =>
           val new_fd = wrapFunDef(fd)
           // Is different since functions will return a boolean as well.
-          val res_id = FreshIdentifier("res", fd.returnType)
-          val res_b = FreshIdentifier("b", BooleanType)
-          if(ids.isEmpty) {
-            val funCall = FunctionInvocation(TypedFunDef(new_fd, targs), children).copiedFrom(e)
-            (exprBuilder(funCall), Seq(res_b))
-          } else {
-            val finalIds = (ids :+ res_b)
-            val finalExpr = 
-              tupleWrap(Seq(Variable(res_id), or(finalIds.map(Variable(_)): _*)))
-            val funCall = letTuple(Seq(res_id, res_b), FunctionInvocation(TypedFunDef(new_fd, targs), children).copiedFrom(e), finalExpr)
-            (exprBuilder(funCall), finalIds)
+          tmpIds match {
+            case Seq() =>
+              val funCall = FunctionInvocation(TypedFunDef(new_fd, targs).copiedFrom(tfd), children).copiedFrom(e)
+              (exprBuilder(funCall), if(new_fd != fd) merge(Some(Seq()), ids) else ids)
+            case idvars =>
+              val res_id = FreshIdentifier("res", fd.returnType)
+              val res_b = FreshIdentifier("bb", BooleanType)
+              val finalIds = idvars :+ res_b
+              val finalExpr = 
+                tupleWrap(Seq(Variable(res_id), or(finalIds.map(Variable(_)): _*))).copiedFrom(e)
+              val funCall = letTuple(Seq(res_id, res_b), FunctionInvocation(TypedFunDef(new_fd, targs), children).copiedFrom(e), finalExpr).copiedFrom(e)
+              (exprBuilder(funCall), Some(finalIds))
           }
         case _ =>
-          if(ids.isEmpty) {
-            (e, Seq.empty)
-          } else {
-            val finalExpr = tupleWrap(Seq(builder(children).copiedFrom(e), or(ids.map(Variable): _*)))
-            (exprBuilder(finalExpr), ids)
+          tmpIds match {
+            case Seq() =>
+              (e, ids)
+            case idvars =>
+              val finalExpr = tupleWrap(Seq(builder(children).copiedFrom(e), or(idvars.map(Variable): _*))).copiedFrom(e)
+              (exprBuilder(finalExpr), ids)
           }
       }
   }
@@ -111,11 +137,19 @@ class InputCoverage(fd: FunDef, fds: Set[FunDef])(implicit c: LeonContext, p: Pr
   
   def wrapFunDef(fd: FunDef): FunDef = {
     if(!(cache contains fd)) {
-      val new_fd = fd.duplicate(returnType = TupleType(Seq(fd.returnType, BooleanType)))
-      new_fd.body = None
-      cache += fd -> new_fd
+      cache += fd -> (if(fds(fd)) {
+        val new_fd = fd.duplicate(returnType = TupleType(Seq(fd.returnType, BooleanType)))
+        new_fd.body = None
+        new_fd
+      } else fd)
     }
     cache(fd)
+  }
+  
+  def isNewFunCall(e: Expr): Boolean = e match {
+    case FunctionInvocation(TypedFunDef(fd, targs), args) =>
+      cache.values.exists { f => f == fd }
+    case _ => false
   }
   
   /** The number of expressions is the same as the number of arguments. */

--- a/src/main/scala/leon/synthesis/disambiguation/InputCoverage.scala
+++ b/src/main/scala/leon/synthesis/disambiguation/InputCoverage.scala
@@ -9,8 +9,8 @@ import purescala.ExprOps
 import purescala.Constructors._
 import purescala.Extractors._
 import purescala.Types.{TypeTree, TupleType, BooleanType}
-import purescala.Common.Identifier
-import purescala.Definitions.{FunDef, Program}
+import purescala.Common.{Identifier, FreshIdentifier}
+import purescala.Definitions.{FunDef, Program, TypedFunDef}
 import purescala.DefOps
 import grammars.ValueGrammar
 import bonsai.enumerators.MemoizedEnumerator
@@ -30,24 +30,84 @@ import leon.LeonContext
 class InputCoverage(fd: FunDef, fds: Set[FunDef])(implicit c: LeonContext, p: Program) {
   var numToCoverForEachExample: Int = 1
   
+  /** If the sub-branches contain identifiers, it returns them unchanged.
+      Else it creates a new boolean indicating this branch. */
+  def wrapBranch(e: (Expr, Seq[Identifier])): (Expr, Seq[Identifier]) = {
+    if(e._2.isEmpty) { // No need to introduce a new boolean since if one of the child booleans is true, then this IfExpr has been called.
+      val b = FreshIdentifier("l" + e._1.getPos.line + "c" + e._1.getPos.col)
+      (tupleWrap(Seq(e._1, Variable(b))), Seq(b))
+    } else e
+  }
+  
+  def hasConditionals(e: Expr) = {
+    ExprOps.exists{ case i:IfExpr => true case m: MatchExpr => true case f: FunctionInvocation => true case _ => false}(e)
+  }
+  
+  /** For each branch in the expression, adds a boolean variable such that the new type of the expression is (previousType, Boolean)
+   *  If no variable is output, then the type of the expression is not changed.
+    * Returns the list of boolean variables which appear in the expression */
+  // All functions now return a boolean along with their original return type.
+  def markBranches(e: Expr): (Expr, Seq[Identifier]) =
+    if(!hasConditionals(e)) (e, Seq()) else e match {
+    case IfExpr(cond, thenn, elze) =>
+      val (c1, cv1) = markBranches(cond)
+      val (t1, tv1) = wrapBranch(markBranches(thenn))
+      val (e1, ev1) = wrapBranch(markBranches(elze))
+      // TODO: Deal with the case when t1 and e1 is empty.
+      (IfExpr(c1, t1, e1).copiedFrom(e), cv1 ++ tv1 ++ ev1)
+    case MatchExpr(scrut, cases) =>
+      val (c1, cv1) = markBranches(scrut)
+      val (new_cases, variables) = (cases map { case MatchCase(pattern, opt, rhs) =>
+        val (rhs_new, ids) = wrapBranch(markBranches(rhs))
+        (MatchCase(pattern, opt, rhs_new), ids)
+      }).unzip // TODO: Check for unapply with function pattern ?
+      (MatchExpr(c1, new_cases).copiedFrom(e), variables.flatten)
+    case Operator(lhsrhs, builder) =>
+      val (exprBuilder, children, ids) = (((e: Expr) => e, List[Expr](), ListBuffer[Identifier]()) /: lhsrhs) {
+        case ((exprBuilder, children, ids), arg) =>
+          val (arg1, argv1) = markBranches(arg)
+          if(argv1.nonEmpty) {
+            val arg_id = FreshIdentifier("arg", arg.getType)
+            val arg_b = FreshIdentifier("b", BooleanType)
+            val f = (body: Expr) => letTuple(Seq(arg_id, arg_b), arg1, body)
+            (exprBuilder andThen f, Variable(arg_id)::children, ids ++= argv1)
+          } else {
+            (exprBuilder, arg::children, ids)
+          }
+      }
+      if(e.isInstanceOf[FunctionInvocation]) {
+        // Should be different.
+      } else if(ids.isEmpty) {
+        (e, Seq.empty)
+      } else {
+        val body = tupleWrap(Seq(builder(children).copiedFrom(e), or(ids.map(Variable): _*)))
+        (exprBuilder(body), ids)
+      }
+  }
+  
   /** The number of expressions is the same as the number of arguments. */
   def result(): Stream[Seq[Expr]] = {
     /* Algorithm:
-     * 1) Consider only match/case and if/else statements.
      * def f(x: Int, z: Boolean): Int =
      *   x match {
-     *     case 0 | 1 => 1
+     *     case 0 | 1 =>
+     *       if(z) f(if(z) x else -x, z) else 1
      *     case _ =>
-     *       if(z) x*f(x-1,!z)
-     *       else f(x-1,!z)+f(x-2,!z)
+     *       (if(z) x
+     *       else f(x-1,!z)+f(x-2,!z))*f(x-1,!z)
      *   } 
      * 2) In innermost branches, replace each result by (result, bi) where bi is a boolean described later.
      * def f(x: Int, z: Boolean): (Int, Boolean) =
      *   x match {
-     *     case 0 | 1 => (1, b1)
+     *     case 0 | 1 =>
+     *       if(z) {
+     *         ({val (r, b1) = if(z) (x, bt) else (-x, be)
+     *         val (res, b) = f(r, z)
+     *         (res, b || b1)
      *     case _ =>
-     *       if(z) (x*f(x-1,!z), b2)
+     *       val (res, b) = if(z) (x, b2)
      *       else (f(x-1,!z)+f(x-2,!z), b3)
+     *       (res*f(x-1,!z), b)
      *   } 
      * 3) If the function is recursive, recover the previous values and left-OR them with the returning bi.
      * def f(x: Int, z: Boolean): (Int, Boolean) =
@@ -87,6 +147,9 @@ class InputCoverage(fd: FunDef, fds: Set[FunDef])(implicit c: LeonContext, p: Pr
         (program, fdMap(fd), fds.map(fdMap))
     }
     val addNewReturnVariables = { (p: Program, fd: FunDef, fds: Set[FunDef]) => 
+      
+
+      
       
     }
     

--- a/src/test/scala/leon/integration/solvers/InputCoverageSuite.scala
+++ b/src/test/scala/leon/integration/solvers/InputCoverageSuite.scala
@@ -46,6 +46,7 @@ import leon.test.helpers.ExpressionsDSL
 import leon.synthesis.disambiguation.InputCoverage
 import leon.test.helpers.ExpressionsDSLProgram
 import leon.test.helpers.ExpressionsDSLVariables
+import leon.purescala.Extractors._
 
 class InputCoverageSuite extends LeonTestSuiteWithProgram with Matchers with ScalaFutures with ExpressionsDSLProgram with ExpressionsDSLVariables {
   val sources = List("""
@@ -63,11 +64,26 @@ class InputCoverageSuite extends LeonTestSuiteWithProgram with Matchers with Sca
     |      2
     |    }
     |  }
+    |  
     |  def withIfInIf(cond: Boolean) = {
     |    if(if(cond) false else true) {
     |      1
     |    } else {
     |      2
+    |    }
+    |  }
+    |  
+    |  sealed abstract class A
+    |  case class B() extends A
+    |  case class C(a: Int, tail: A) extends A
+    |  case class D(a: String, tail: A, b: String) extends A
+    |  
+    |  def withMatch(a: A): String = {
+    |    a match {
+    |      case B() => "B"
+    |      case C(a, C(b, tail)) => b.toString + withMatch(tail) + a.toString
+    |      case C(a, tail) => withMatch(tail) + a.toString
+    |      case D(a, tail, b) => a + withMatch(tail) + b
     |    }
     |  }
     |  
@@ -93,10 +109,14 @@ class InputCoverageSuite extends LeonTestSuiteWithProgram with Matchers with Sca
     val dummy = funDef("InputCoverageSuite.dummy")
     val coverage = new InputCoverage(dummy, Set(dummy))
     val simpleExpr = Plus(IntLiteral(1), b)
-    coverage.wrapBranch((simpleExpr, Seq(p.id, q.id))) should equal ((simpleExpr, Seq(p.id, q.id)))
-    val (covered, ids) = coverage.wrapBranch((simpleExpr, Seq()))
-    ids should have size 1
-    covered should equal (Tuple(Seq(simpleExpr, Variable(ids.head))))
+    coverage.wrapBranch((simpleExpr, Some(Seq(p.id, q.id)))) should equal ((simpleExpr, Some(Seq(p.id, q.id))))
+    coverage.wrapBranch((simpleExpr, None)) match {
+      case (covered, Some(ids)) =>
+        ids should have size 1
+        covered should equal (Tuple(Seq(simpleExpr, Variable(ids.head))))
+      case _ =>
+        fail("No ids added")
+    }
   }
   
   test("If-coverage should work"){ ctxprogram =>
@@ -105,12 +125,16 @@ class InputCoverageSuite extends LeonTestSuiteWithProgram with Matchers with Sca
     val coverage = new InputCoverage(withIf, Set(withIf))
     val expr = withIf.body.get
     
-    val (res, ids) = coverage.markBranches(expr)
-    ids should have size 2
-    expr match {
-      case IfExpr(cond, thenn, elze) =>
-        res should equal (IfExpr(cond, Tuple(Seq(thenn, Variable(ids(0)))), Tuple(Seq(elze, Variable(ids(1))))))
-      case _ => fail(s"$expr is not an IfExpr")
+    coverage.markBranches(expr) match {
+      case (res, Some(ids)) =>
+        ids should have size 2
+        expr match {
+          case IfExpr(cond, thenn, elze) =>
+            res should equal (IfExpr(cond, Tuple(Seq(thenn, Variable(ids(0)))), Tuple(Seq(elze, Variable(ids(1))))))
+          case _ => fail(s"$expr is not an IfExpr")
+        }
+      case _ =>
+        fail("No ids added")
     }
   }
   
@@ -120,15 +144,52 @@ class InputCoverageSuite extends LeonTestSuiteWithProgram with Matchers with Sca
     val coverage = new InputCoverage(withIfInIf, Set(withIfInIf))
     val expr = withIfInIf.body.get
     
-    val (res, ids) = coverage.markBranches(expr)
-    ids should have size 4
-    expr match {
-      case IfExpr(IfExpr(cond, t1, e1), t2, e2) =>
-        res match {
-          case MatchExpr(IfExpr(c, t1, e1), Seq(MatchCase(TuplePattern(None, s), None, IfExpr(c2, t2, e2)))) if s.size == 2 =>
-          case _ => fail("should have a shape like (if() else ) match { case (a, b) => if(...) else }")
+    coverage.markBranches(expr) match {
+      case (res, None) => fail("No ids added")
+      case (res, Some(ids)) =>
+        ids should have size 4
+        expr match {
+          case IfExpr(IfExpr(cond, t1, e1), t2, e2) =>
+            res match {
+              case MatchExpr(IfExpr(c, t1, e1), Seq(MatchCase(TuplePattern(None, s), None, IfExpr(c2, t2, e2)))) if s.size == 2 =>
+              case _ => fail("should have a shape like (if() else ) match { case (a, b) => if(...) else }")
+            }
+          case _ => fail(s"$expr is not an IfExpr")
         }
-      case _ => fail(s"$expr is not an IfExpr")
+    }
+  }
+  
+  test("Match coverage should work with recursive functions") { ctxprogram =>
+    implicit val (c, p) = ctxprogram
+    val withMatch = funDef("InputCoverageSuite.withMatch")
+    val coverage = new InputCoverage(withMatch, Set(withMatch))
+    val expr = withMatch.body.get
+    
+    coverage.markBranches(expr) match {
+      case (res, None) => fail("No ids added")
+      case (res, Some(ids)) =>
+        withClue(res.toString) {
+          ids should have size 4
+          res match {
+            case MatchExpr(scrut,
+                   Seq(
+                       MatchCase(CaseClassPattern(_, _, Seq()), None, rhs1),
+                       MatchCase(CaseClassPattern(_, _, _), None, rhs2),
+                       MatchCase(CaseClassPattern(_, _, _), None, rhs3),
+                       MatchCase(CaseClassPattern(_, _, _), None, rhs4))
+            ) =>
+              rhs1 match {
+                case Tuple(Seq(_, Variable(b))) => b shouldEqual ids(0)
+                case _ => fail(s"$rhs1 should be a Tuple")
+              }
+              rhs2 match {
+                case LetTuple(_, _, Tuple(Seq(_, Or(Seq(_, Variable(b)))))) => b shouldEqual ids(1)
+                case _ => fail(s"$rhs2 should be a val + tuple like val ... = ... ; (..., ... || ${ids(1)})")
+              }
+              
+            case _ => fail(s"$res does not have the format a match { case B() => .... x 4 }")
+          }
+        }
     }
   }
   
@@ -139,24 +200,28 @@ class InputCoverageSuite extends LeonTestSuiteWithProgram with Matchers with Sca
     val coverage = new InputCoverage(withCoveredFun1, Set(withCoveredFun1, withCoveredFun2))
     val expr = withCoveredFun1.body.get
     
-    val (res, ids) = coverage.markBranches(expr)
-    ids should have size 2
-    
-    res match {
-      case MatchExpr(funCall, Seq(
-            MatchCase(TuplePattern(None, Seq(WildcardPattern(Some(a1)), WildcardPattern(Some(b1)))), None,
-              MatchExpr(funCall2, Seq(
-                MatchCase(TuplePattern(None, Seq(WildcardPattern(Some(a2)), WildcardPattern(Some(b2)))), None,
-                  Tuple(Seq(BVPlus(Variable(ida1), Variable(ida2)), Or(Seq(Variable(idb1), Variable(idb2)))))
-            )
-          ))))) =>
+    coverage.markBranches(expr) match {
+      case (res, Some(ids)) if ids.size > 0 =>
         withClue(res.toString) {
-          ida1 shouldEqual a1
-          ida2 shouldEqual a2
-          Set(idb1.uniqueName, idb2.uniqueName) shouldEqual Set(b1.uniqueName, b2.uniqueName)
+          fail(s"Should have not added any ids, but got $ids")
         }
-      case _ =>
-        fail(s"$res is not of type funCall() match { case (a1, b1) => funCall() match { case (a2, b2) => (a1 + a2, b1 || b2) } }")
+      case (res, _) =>
+        res match {
+          case MatchExpr(funCall, Seq(
+                MatchCase(TuplePattern(None, Seq(WildcardPattern(Some(a1)), WildcardPattern(Some(b1)))), None,
+                  MatchExpr(funCall2, Seq(
+                    MatchCase(TuplePattern(None, Seq(WildcardPattern(Some(a2)), WildcardPattern(Some(b2)))), None,
+                      Tuple(Seq(BVPlus(Variable(ida1), Variable(ida2)), Or(Seq(Variable(idb1), Variable(idb2)))))
+                )
+              ))))) =>
+            withClue(res.toString) {
+              ida1.uniqueName shouldEqual a2.uniqueName
+              ida2.uniqueName shouldEqual a1.uniqueName
+              Set(idb1.uniqueName, idb2.uniqueName) shouldEqual Set(b1.uniqueName, b2.uniqueName)
+            }
+          case _ =>
+            fail(s"$res is not of type funCall() match { case (a1, b1) => funCall() match { case (a2, b2) => (a1 + a2, b1 || b2) } }")
+        }
     }
   }
   
@@ -167,18 +232,20 @@ class InputCoverageSuite extends LeonTestSuiteWithProgram with Matchers with Sca
     val coverage = new InputCoverage(withCoveredFun3, Set(withCoveredFun3, withCoveredFun2))
     val expr = withCoveredFun3.body.get
     
-    val (res, ids) = coverage.markBranches(expr)
-    ids should have size 2
-    res match {
-      case MatchExpr(funCall, Seq(
-            MatchCase(TuplePattern(None, Seq(WildcardPattern(Some(a)), WildcardPattern(Some(b1)))), None,
-              MatchExpr(FunctionInvocation(_, Seq(Variable(ida))), Seq(
-                MatchCase(TuplePattern(None, Seq(WildcardPattern(_), WildcardPattern(Some(b2)))), None,
-                  Tuple(Seq(p, Or(Seq(Variable(id1), Variable(id2)))))
-            )
-          ))))) if ida == a && id1 == b1 && id2 == b2 =>
-      case _ =>
-        fail(s"$res is not of type funCall() match { case (a, b1) => funCall(a) match { case (c, b2) => (c, b1 || b2) } }")
+    coverage.markBranches(expr) match {
+      case (res, None) => fail("No ids added")
+      case (res, Some(ids)) =>
+        res match {
+          case MatchExpr(funCall, Seq(
+                MatchCase(TuplePattern(None, Seq(WildcardPattern(Some(a)), WildcardPattern(Some(b1)))), None,
+                  MatchExpr(FunctionInvocation(_, Seq(Variable(ida))), Seq(
+                    MatchCase(TuplePattern(None, Seq(WildcardPattern(_), WildcardPattern(Some(b2)))), None,
+                      Tuple(Seq(p, Or(Seq(Variable(id1), Variable(id2)))))
+                )
+              ))))) if ida == a && id1 == b1 && id2 == b2 =>
+          case _ =>
+            fail(s"$res is not of type funCall() match { case (a, b1) => funCall(a) match { case (c, b2) => (c, b1 || b2) } }")
+        }
     }
   }
 }

--- a/src/test/scala/leon/integration/solvers/InputCoverageSuite.scala
+++ b/src/test/scala/leon/integration/solvers/InputCoverageSuite.scala
@@ -1,0 +1,184 @@
+package leon.integration.solvers
+
+import org.scalatest.FunSuite
+import org.scalatest.Matchers
+import leon.test.helpers.ExpressionsDSL
+import leon.solvers.string.StringSolver
+import leon.purescala.Common.FreshIdentifier
+import leon.purescala.Common.Identifier
+import leon.purescala.Expressions._
+import leon.purescala.Definitions._
+import leon.purescala.DefOps
+import leon.purescala.ExprOps
+import leon.purescala.Types._
+import leon.purescala.TypeOps
+import leon.purescala.Constructors._
+import leon.synthesis.rules.{StringRender, TypedTemplateGenerator}
+import scala.collection.mutable.{HashMap => MMap}
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+import org.scalatest.concurrent.Timeouts
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.SpanSugar._
+import org.scalatest.FunSuite
+import org.scalatest.concurrent.Timeouts
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.SpanSugar._
+import leon.purescala.Types.Int32Type
+import leon.test.LeonTestSuiteWithProgram
+import leon.synthesis.SourceInfo
+import leon.synthesis.CostModels
+import leon.synthesis.graph.AndNode
+import leon.synthesis.SearchContext
+import leon.synthesis.Synthesizer
+import leon.synthesis.SynthesisSettings
+import leon.synthesis.RuleApplication
+import leon.synthesis.RuleClosed
+import leon.evaluators._
+import leon.LeonContext
+import leon.synthesis.rules.DetupleInput
+import leon.synthesis.Rules
+import leon.solvers.ModelBuilder
+import scala.language.implicitConversions
+import leon.LeonContext
+import leon.test.LeonTestSuiteWithProgram
+import leon.test.helpers.ExpressionsDSL
+import leon.synthesis.disambiguation.InputCoverage
+import leon.test.helpers.ExpressionsDSLProgram
+import leon.test.helpers.ExpressionsDSLVariables
+
+class InputCoverageSuite extends LeonTestSuiteWithProgram with Matchers with ScalaFutures with ExpressionsDSLProgram with ExpressionsDSLVariables {
+  val sources = List("""
+    |import leon.lang._
+    |import leon.collection._
+    |import leon.lang.synthesis._
+    |import leon.annotation._
+    |
+    |object InputCoverageSuite {
+    |  def dummy = 2
+    |  def withIf(cond: Boolean) = {
+    |    if(cond) {
+    |      1
+    |    } else {
+    |      2
+    |    }
+    |  }
+    |  def withIfInIf(cond: Boolean) = {
+    |    if(if(cond) false else true) {
+    |      1
+    |    } else {
+    |      2
+    |    }
+    |  }
+    |  
+    |  def withCoveredFun1(input: Int) = {
+    |    withCoveredFun2(input - 5) + withCoveredFun2(input + 5)
+    |  }
+    |  
+    |  def withCoveredFun2(input: Int) = {
+    |    if(input > 0) {
+    |      2
+    |    } else {
+    |      0
+    |    }
+    |  }
+    |  
+    |  def withCoveredFun3(input: Int) = {
+    |    withCoveredFun2(withCoveredFun2(input + 5))
+    |  }
+    |}""".stripMargin)
+    
+  test("wrapBranch should wrap expressions if they are not already containing wrapped calls"){ ctxprogram =>
+    implicit val (c, p) = ctxprogram
+    val dummy = funDef("InputCoverageSuite.dummy")
+    val coverage = new InputCoverage(dummy, Set(dummy))
+    val simpleExpr = Plus(IntLiteral(1), b)
+    coverage.wrapBranch((simpleExpr, Seq(p.id, q.id))) should equal ((simpleExpr, Seq(p.id, q.id)))
+    val (covered, ids) = coverage.wrapBranch((simpleExpr, Seq()))
+    ids should have size 1
+    covered should equal (Tuple(Seq(simpleExpr, Variable(ids.head))))
+  }
+  
+  test("If-coverage should work"){ ctxprogram =>
+    implicit val (c, p) = ctxprogram
+    val withIf = funDef("InputCoverageSuite.withIf")
+    val coverage = new InputCoverage(withIf, Set(withIf))
+    val expr = withIf.body.get
+    
+    val (res, ids) = coverage.markBranches(expr)
+    ids should have size 2
+    expr match {
+      case IfExpr(cond, thenn, elze) =>
+        res should equal (IfExpr(cond, Tuple(Seq(thenn, Variable(ids(0)))), Tuple(Seq(elze, Variable(ids(1))))))
+      case _ => fail(s"$expr is not an IfExpr")
+    }
+  }
+  
+  test("If-cond-coverage should work"){ ctxprogram =>
+    implicit val (c, p) = ctxprogram
+    val withIfInIf = funDef("InputCoverageSuite.withIfInIf")
+    val coverage = new InputCoverage(withIfInIf, Set(withIfInIf))
+    val expr = withIfInIf.body.get
+    
+    val (res, ids) = coverage.markBranches(expr)
+    ids should have size 4
+    expr match {
+      case IfExpr(IfExpr(cond, t1, e1), t2, e2) =>
+        res match {
+          case MatchExpr(IfExpr(c, t1, e1), Seq(MatchCase(TuplePattern(None, s), None, IfExpr(c2, t2, e2)))) if s.size == 2 =>
+          case _ => fail("should have a shape like (if() else ) match { case (a, b) => if(...) else }")
+        }
+      case _ => fail(s"$expr is not an IfExpr")
+    }
+  }
+  
+  test("fundef combination-coverage should work"){ ctxprogram =>
+    implicit val (c, p) = ctxprogram
+    val withCoveredFun1 = funDef("InputCoverageSuite.withCoveredFun1")
+    val withCoveredFun2 = funDef("InputCoverageSuite.withCoveredFun2")
+    val coverage = new InputCoverage(withCoveredFun1, Set(withCoveredFun1, withCoveredFun2))
+    val expr = withCoveredFun1.body.get
+    
+    val (res, ids) = coverage.markBranches(expr)
+    ids should have size 2
+    
+    res match {
+      case MatchExpr(funCall, Seq(
+            MatchCase(TuplePattern(None, Seq(WildcardPattern(Some(a1)), WildcardPattern(Some(b1)))), None,
+              MatchExpr(funCall2, Seq(
+                MatchCase(TuplePattern(None, Seq(WildcardPattern(Some(a2)), WildcardPattern(Some(b2)))), None,
+                  Tuple(Seq(BVPlus(Variable(ida1), Variable(ida2)), Or(Seq(Variable(idb1), Variable(idb2)))))
+            )
+          ))))) =>
+        withClue(res.toString) {
+          ida1 shouldEqual a1
+          ida2 shouldEqual a2
+          Set(idb1.uniqueName, idb2.uniqueName) shouldEqual Set(b1.uniqueName, b2.uniqueName)
+        }
+      case _ =>
+        fail(s"$res is not of type funCall() match { case (a1, b1) => funCall() match { case (a2, b2) => (a1 + a2, b1 || b2) } }")
+    }
+  }
+  
+  test("fundef composition-coverage should work"){ ctxprogram =>
+    implicit val (c, p) = ctxprogram
+    val withCoveredFun2 = funDef("InputCoverageSuite.withCoveredFun2")
+    val withCoveredFun3 = funDef("InputCoverageSuite.withCoveredFun3")
+    val coverage = new InputCoverage(withCoveredFun3, Set(withCoveredFun3, withCoveredFun2))
+    val expr = withCoveredFun3.body.get
+    
+    val (res, ids) = coverage.markBranches(expr)
+    ids should have size 2
+    res match {
+      case MatchExpr(funCall, Seq(
+            MatchCase(TuplePattern(None, Seq(WildcardPattern(Some(a)), WildcardPattern(Some(b1)))), None,
+              MatchExpr(FunctionInvocation(_, Seq(Variable(ida))), Seq(
+                MatchCase(TuplePattern(None, Seq(WildcardPattern(_), WildcardPattern(Some(b2)))), None,
+                  Tuple(Seq(p, Or(Seq(Variable(id1), Variable(id2)))))
+            )
+          ))))) if ida == a && id1 == b1 && id2 == b2 =>
+      case _ =>
+        fail(s"$res is not of type funCall() match { case (a, b1) => funCall(a) match { case (c, b2) => (c, b1 || b2) } }")
+    }
+  }
+}

--- a/src/test/scala/leon/integration/solvers/InputCoverageSuite.scala
+++ b/src/test/scala/leon/integration/solvers/InputCoverageSuite.scala
@@ -248,4 +248,11 @@ class InputCoverageSuite extends LeonTestSuiteWithProgram with Matchers with Sca
         }
     }
   }
+  
+  test("input coverage for booleans should find all of them") { ctxprogram =>
+    implicit val (c, p) = ctxprogram
+    val withIf = funDef("InputCoverageSuite.withIf")
+    val coverage = new InputCoverage(withIf, Set(withIf))
+    coverage.result().toSet should equal (Set(Seq(b(true)), Seq(b(false))))
+  }
 }

--- a/src/test/scala/leon/test/helpers/ExpressionsDSL.scala
+++ b/src/test/scala/leon/test/helpers/ExpressionsDSL.scala
@@ -9,6 +9,10 @@ import leon.purescala.Common._
 import leon.purescala.Types._
 import leon.purescala.Expressions._
 
+trait ExpressionsDSLVariables_a {
+  val a = FreshIdentifier("a", Int32Type).toVariable
+}
+
 trait ExpressionsDSLVariables {
   val F = BooleanLiteral(false)
   val T = BooleanLiteral(true)
@@ -18,7 +22,6 @@ trait ExpressionsDSLVariables {
   def i(x: Int)     = IntLiteral(x)
   def r(n: BigInt, d: BigInt)  = FractionalLiteral(n, d)
 
-  val a = FreshIdentifier("a", Int32Type).toVariable
   val b = FreshIdentifier("b", Int32Type).toVariable
   val c = FreshIdentifier("c", Int32Type).toVariable
 
@@ -97,7 +100,7 @@ self: Assertions =>
   }
 }
 
-trait ExpressionsDSL extends ExpressionsDSLVariables with ExpressionsDSLProgram {
+trait ExpressionsDSL extends ExpressionsDSLVariables with ExpressionsDSLProgram with ExpressionsDSLVariables_a {
   self: Assertions =>
   
 }


### PR DESCRIPTION
With this API, one can now find a set of inputs for a function `f` such that all lines of code of a set of functions `fds` are covered during the execution of `f` on each of these inputs. To do so:

    new InputCoverage(f, fds)(ctx, program).result()

will return the set of inputs.
The test suite ensures that this functionality is not broken.



