### PR TITLE
Fixed ExprOps.isValue for covariant/contravariant function types.

### DIFF
--- a/src/main/scala/leon/purescala/SelfPrettyPrinter.scala
+++ b/src/main/scala/leon/purescala/SelfPrettyPrinter.scala
@@ -109,12 +109,11 @@ class SelfPrettyPrinter {
       case _ => false
     } match {
       case None => orElse
-      case Some(l) =>
-        ctx.reporter.debug("Executing pretty printer for type " + v.getType + " : " + l + " on " + v)
+      case Some(Lambda(Seq(ValDef(id)), body)) =>
+        ctx.reporter.debug("Executing pretty printer for type " + v.getType + " : " + v + " on " + v)
         val ste = new DefaultEvaluator(ctx, program)
         try {
-          val toEvaluate = application(l, Seq(v))
-          val result = ste.eval(toEvaluate)
+          val result = ste.eval(body, Map(id -> v))
           
           result.result match {
             case Some(StringLiteral(res)) if res != "" =>


### PR DESCRIPTION
Fixed SelfPrettyPrinter to not evaluate the argument again.
Removed unused debug variable.