### PR TITLE
disable bodies for `takeI`/`dropI`

### DIFF
--- a/library/theories/String.scala
+++ b/library/theories/String.scala
@@ -30,11 +30,13 @@ sealed abstract class String {
     case _ => this
   }
   
+  @isabelle.noBody()
   def takeI(i: Int): String = this match {
     case StringCons(head, tail) if i > 0 => StringCons(head, tail takeI (i - 1))
     case _ => StringNil()
   }
 
+  @isabelle.noBody()
   def dropI(i: Int): String = this match {
     case StringCons(head, tail) if i > 0 => tail dropI (i - 1)
     case _ => this


### PR DESCRIPTION
Isabelle can't prove termination for those methods which have been introduced in 61c7302.

(This should fix the build.)