### PR TITLE
Recursive + inline string repair.

### DIFF
--- a/src/main/scala/leon/purescala/PrettyPrinter.scala
+++ b/src/main/scala/leon/purescala/PrettyPrinter.scala
@@ -98,12 +98,15 @@ class PrettyPrinter(opts: PrinterOptions,
         p"""|val $b = $d
             |$e"""
 
-      case LetDef(a :: q, body) =>
+      case LetDef(a +: q, body) =>
         p"""|$a
             |${letDef(q, body)}"""
       case LetDef(Nil, body) =>
         p"""$body"""
 
+      case Require(BooleanLiteral(true), body) =>
+        p"|$body"
+        
       case Require(pre, body) =>
         p"""|require($pre)
             |$body"""

--- a/src/main/scala/leon/synthesis/disambiguation/InputPatternCoverage.scala
+++ b/src/main/scala/leon/synthesis/disambiguation/InputPatternCoverage.scala
@@ -177,7 +177,7 @@ class InputPatternCoverage(fd: TypedFunDef)(implicit c: LeonContext, p: Program)
           coverExpr(inputs, elze, covered, bindings)
       )
       
-    case IfExpr(cond, thenn, elze) => throw new Exception("Requires only match/case pattern, got "+e)
+    case IfExpr(cond, thenn, elze) => throw new InputPatternCoverageException("Requires only match/case pattern, got "+e)
     case MatchExpr(Reconstructor(path), cases) if inputs.nonEmpty && inputs.headOption == Some(path.orig) =>
       val pathType = path.getType
       val coveringExprs = cases.map(coverMatchCase(pathType, _, covered, bindings))

--- a/src/main/scala/leon/utils/Positions.scala
+++ b/src/main/scala/leon/utils/Positions.scala
@@ -35,6 +35,7 @@ abstract class Position extends Ordered[Position] {
 }
 
 object Position {
+  /** Merges the two positions into the smallest RangePosition containing both positions */
   def between(a: Position, b: Position): Position = {
     if (a.file == b.file) {
       if (a.line == b.line && a.col == b.col) {
@@ -57,6 +58,29 @@ object Position {
       }
     } else {
       a
+    }
+  }
+  
+  /** Returns true if position a is inside position b.*/
+  def isInside(a: Position, b: Position): Boolean = {
+    b match {
+      case b: OffsetPosition =>
+        a match {
+          case OffsetPosition(line, col, point, file) =>
+            file == b.file && point == b.point
+          case RangePosition(line, col, pointFrom, line2, col2, pointTo, file) =>
+            file == b.file && pointFrom == b.point && pointTo == pointFrom
+          case _ => false
+        }
+      case b: RangePosition =>
+        a match {
+          case OffsetPosition(line, col, point, file) =>
+            file == b.file && point >= b.pointFrom && point <= b.pointTo
+          case RangePosition(line, col, pointFrom, line2, col2, pointTo, file) =>
+            file == b.file && pointFrom >= b.pointFrom && pointTo <= b.pointTo
+          case _ => false
+        }
+      case _ => false
     }
   }
 }

--- a/testcases/stringrender/Repair.scala
+++ b/testcases/stringrender/Repair.scala
@@ -1,0 +1,56 @@
+/** 
+  * Name:     Repair.scala
+  * Creation: 07.09.2016
+  * Author:   Mikael Mayer (mikael.mayer@epfl.ch)
+  * Comments: Opportunity to repair string programs.
+  */
+import leon.lang._
+import leon.collection._
+
+object StringRepair {
+  // Two changes needed
+  def test(a : List[String]): String =  {
+    "(" + List.mkString[String](a, ", ", (s : String) => s) + ")"
+  } ensuring {
+    (res : String) => (a, res) passes {
+      case Cons("A", Nil()) =>
+        "[A]"
+    }
+  }
+  
+  // One change needed on a recursive function
+  def unary(a: BigInt): String= {
+    if(a <= 0) ""
+    else "i" + unary(a-1)
+  } ensuring {
+    (res: String) => (a, res) passes {
+      case a if a == BigInt(3) => "kkk"
+    }
+  }
+  
+  // Two changes needed on one recursive function
+  def boundaries(a: List[BigInt]): String= {
+    def boundariesrec(a: BigInt): String = {
+      if(a <= 0) ";"
+      else "=" + boundariesrec(a-1)
+    }
+    List.mkString[BigInt](a, " ", boundariesrec)
+  } ensuring {
+    (res: String) => (a, res) passes {
+      case a if a == List(BigInt(1), BigInt(2)) => "=|=="
+    }
+  }
+  
+  // Three changes requiring clarification.
+  def boundaries2(a: List[BigInt]): String= {
+    def boundaries2rec(a: BigInt): String = {
+      if(a <= 0) ";"
+      else "i" + boundaries2rec(a-1)
+    }
+    List.mkString[BigInt](a, " ", boundaries2rec)
+  } ensuring {
+    (res: String) => (a, res) passes {
+      case a if a == List(BigInt(1), BigInt(2)) => "=|=="
+    }
+  }
+}

--- a/testcases/web/synthesis/28_String_Repair.scala
+++ b/testcases/web/synthesis/28_String_Repair.scala
@@ -1,0 +1,50 @@
+import leon.lang._
+import leon.collection._
+
+object StringRepair {
+  // Two changes needed
+  def test(a : List[String]): String =  {
+    "(" + List.mkString[String](a, ", ", (s : String) => s) + ")"
+  } ensuring {
+    (res : String) => (a, res) passes {
+      case Cons("A", Nil()) =>
+        "[A]"
+    }
+  }
+  
+  // One change needed on a recursive function
+  def unary(a: BigInt): String= {
+    if(a <= 0) ""
+    else "i" + unary(a-1)
+  } ensuring {
+    (res: String) => (a, res) passes {
+      case a if a == BigInt(3) => "kkk"
+    }
+  }
+  
+  // Two changes needed on one recursive function
+  def boundaries(a: List[BigInt]): String= {
+    def boundariesrec(a: BigInt): String = {
+      if(a <= 0) ";"
+      else "=" + boundariesrec(a-1)
+    }
+    List.mkString[BigInt](a, " ", boundariesrec)
+  } ensuring {
+    (res: String) => (a, res) passes {
+      case a if a == List(BigInt(1), BigInt(2)) => "=|=="
+    }
+  }
+  
+  // Three changes requiring clarification.
+  def boundaries2(a: List[BigInt]): String= {
+    def boundaries2rec(a: BigInt): String = {
+      if(a <= 0) ";"
+      else "i" + boundaries2rec(a-1)
+    }
+    List.mkString[BigInt](a, " ", boundaries2rec)
+  } ensuring {
+    (res: String) => (a, res) passes {
+      case a if a == List(BigInt(1), BigInt(2)) => "=|=="
+    }
+  }
+}


### PR DESCRIPTION
Fixed pretty-printing of letdefs.
Require(true) now removed from pretty-printing.
InputPatternCoverage only throwing its own exceptions.
StringRender has now Preprocessing normalization rule.
Interruptible StringRender.
Inside position code.
Added testcases and web file for StringRepair.