### PR TITLE
Topic/class restrictions: directly reject invalid abstract class from the frontend

### DIFF
--- a/src/main/scala/leon/frontends/scalac/CodeExtraction.scala
+++ b/src/main/scala/leon/frontends/scalac/CodeExtraction.scala
@@ -218,6 +218,10 @@ trait CodeExtraction extends ASTExtractors {
       val valDefs = constructor.vparamss.flatten
       if (valDefs.nonEmpty)
         outOfSubsetError(tmpl.pos, "Abstract class with fields are not supported")
+
+      val vars = tmpl.body collect { case vd @ ValDef(mods, _, _, _) if mods.isMutable => vd }
+      if (vars.nonEmpty)
+        outOfSubsetError(tmpl.pos, "Abstract class with variable fields are not supported")
     }
 
     private def collectClassSymbols(defs: List[Tree]) {

--- a/src/main/scala/leon/utils/TypingPhase.scala
+++ b/src/main/scala/leon/utils/TypingPhase.scala
@@ -16,7 +16,7 @@ object TypingPhase extends SimpleLeonPhase[Program, Program] {
   val description = "Ensure and enforce certain Leon typing rules"
 
   /**
-   * This phase does 2 different things:
+   * This phase does 3 different things:
    *
    * 1) Ensure that functions that take and/or return a specific ADT subtype
    *    have this encoded explicitly in pre/postconditions. Solvers such as Z3

--- a/src/test/resources/regression/frontends/error/simple/AbstractClassWithField.scala
+++ b/src/test/resources/regression/frontends/error/simple/AbstractClassWithField.scala
@@ -1,0 +1,7 @@
+/* Copyright 2009-2016 EPFL, Lausanne */
+
+object AbstractClassWithField {
+  abstract class Base(x: Int)
+  case class Derived() extends Base(42)
+}
+

--- a/src/test/resources/regression/frontends/error/simple/AbstractClassWithVar.scala
+++ b/src/test/resources/regression/frontends/error/simple/AbstractClassWithVar.scala
@@ -1,0 +1,9 @@
+/* Copyright 2009-2016 EPFL, Lausanne */
+
+object AbstractClassWithVar {
+  abstract class Base() {
+    var x = 0
+  }
+  case class Derived() extends Base()
+}
+

--- a/src/test/resources/regression/frontends/passing/ValidAbstractClassWithField.scala
+++ b/src/test/resources/regression/frontends/passing/ValidAbstractClassWithField.scala
@@ -1,0 +1,9 @@
+/* Copyright 2009-2016 EPFL, Lausanne */
+
+object ValidAbstractClassWithField {
+  abstract class Base() {
+    val x = 42
+  }
+  case class Derived() extends Base
+}
+


### PR DESCRIPTION
This modifies `leon/frontends/scalac/CodeExtraction.scala` to explicitly reject what is considered "invalid" (i.e. not supported) abstract classes.

I've added those checks because the rest of Leon's pipeline seems to be bases on the assumption that abstract classes have no fields.