### PR TITLE
Topic/inline option: add @inline on some of leon.lang.Option methods

### DIFF
--- a/library/leon/lang/Option.scala
+++ b/library/leon/lang/Option.scala
@@ -16,11 +16,13 @@ sealed abstract class Option[T] {
     }
   }
 
+  @inline
   def getOrElse(default: =>T) = this match {
     case Some(v) => v
     case None()  => default
   }
 
+  @inline
   def orElse(or: =>Option[T]) = { this match {
     case Some(v) => this
     case None() => or
@@ -39,30 +41,36 @@ sealed abstract class Option[T] {
 
 
   // Higher-order API
+  @inline
   @isabelle.function(term = "%x f. Option.map_option f x")
   def map[R](f: T => R) = { this match {
     case None() => None[R]()
     case Some(x) => Some(f(x))
   }} ensuring { _.isDefined == this.isDefined }
 
+  @inline
   @isabelle.function(term = "Option.bind")
   def flatMap[R](f: T => Option[R]) = this match {
     case None() => None[R]()
     case Some(x) => f(x)
   }
 
+  @inline
   def filter(p: T => Boolean) = this match {
     case Some(x) if p(x) => Some(x)
     case _ => None[T]()
   }
 
+  @inline
   def withFilter(p: T => Boolean) = filter(p)
 
+  @inline
   def forall(p: T => Boolean) = this match {
-    case Some(x) if !p(x) => false 
+    case Some(x) if !p(x) => false
     case _ => true
   }
 
+  @inline
   def exists(p: T => Boolean) = !forall(!p(_))
 
   // Transformation to other collections
@@ -70,7 +78,7 @@ sealed abstract class Option[T] {
     case None() => Nil[T]()
     case Some(x) => List(x)
   }
-  
+
   def toSet: Set[T] = this match {
     case None() => Set[T]()
     case Some(x) => Set(x)

--- a/library/leon/lang/Option.scala
+++ b/library/leon/lang/Option.scala
@@ -11,9 +11,7 @@ sealed abstract class Option[T] {
 
   def get : T = {
     require(this.isDefined)
-    (this : @unchecked) match {
-      case Some(x) => x
-    }
+    this.asInstanceOf[Some[T]].v
   }
 
   @inline

--- a/src/main/scala/leon/invariant/datastructure/Graph.scala
+++ b/src/main/scala/leon/invariant/datastructure/Graph.scala
@@ -2,6 +2,7 @@
 
 package leon
 package invariant.datastructure
+import purescala.Definitions._
 
 /**
  * The trait represents a graph-like data structure supporting the following operations.
@@ -67,7 +68,7 @@ trait Graph[T] {
         BFSReachRecur(head)
       }
     }
-    srcs.foreach{src => BFSReachRecur(src) }
+    srcs.foreach { src => BFSReachRecur(src) }
     visited
   }
 
@@ -80,11 +81,11 @@ trait Graph[T] {
     type Component = List[T]
 
     case class State(count: Int,
-      visited: Set[T],
-      dfNumber: Map[T, Int],
-      lowlinks: Map[T, Int],
-      stack: List[T],
-      components: List[Component])
+                     visited: Set[T],
+                     dfNumber: Map[T, Int],
+                     lowlinks: Map[T, Int],
+                     stack: List[T],
+                     components: List[Component])
 
     def search(vertex: T, state: State): State = {
       val newState = state.copy(visited = state.visited + vertex,
@@ -106,6 +107,7 @@ trait Graph[T] {
         }
       }
       val strslt = successors(vertex).foldLeft(newState)(processNeighbor)
+
       if (strslt.lowlinks(vertex) == strslt.dfNumber(vertex)) {
         val index = strslt.stack.indexOf(vertex)
         val (comp, rest) = strslt.stack.splitAt(index + 1)
@@ -158,7 +160,7 @@ class DirectedGraph[T] extends Graph[T] {
   }
 
   def removeEdge(src: T, dest: T): Unit = {
-    if (adjlist.contains(src) && adjlist(src).contains(dest)){
+    if (adjlist.contains(src) && adjlist(src).contains(dest)) {
       val nset = adjlist(src) - dest
       adjlist.update(src, nset)
       edgeCount -= 1
@@ -179,7 +181,7 @@ class DirectedGraph[T] extends Graph[T] {
    */
   def reverse = {
     val revg = new DirectedGraph[T]()
-    adjlist.foreach{
+    adjlist.foreach {
       case (src, dests) =>
         dests.foreach { revg.addEdge(_, src) }
     }
@@ -235,9 +237,9 @@ class DirectedLabeledGraph[T, L](private val dgraph: DirectedGraph[T] = new Dire
       case (edge, edgeLabels) if (edgeLabels -- remlabels).isEmpty =>
         edgesToRemove += edge
       case (edge, edgeLabels) =>
-        nlg.labels.update(edge, (edgeLabels -- remlabels))        
+        nlg.labels.update(edge, (edgeLabels -- remlabels))
     }
-    edgesToRemove.foreach{ case (src, dest) => nlg.dgraph.removeEdge(src, dest) }
+    edgesToRemove.foreach { case (src, dest) => nlg.dgraph.removeEdge(src, dest) }
     nlg
   }
 
@@ -246,15 +248,15 @@ class DirectedLabeledGraph[T, L](private val dgraph: DirectedGraph[T] = new Dire
     var edgesToRemove = Set[Edge]()
     labels.foreach {
       case (edge, edgeLabels) if !edgeLabels(label) => edgesToRemove += edge
-      case _ =>
+      case _                                        =>
     }
-    edgesToRemove.foreach{ case (src, dest) => ng.removeEdge(src, dest) }
+    edgesToRemove.foreach { case (src, dest) => ng.removeEdge(src, dest) }
     ng
   }
 
   def reverse = {
     val nlg = new DirectedLabeledGraph[T, L](dgraph.reverse)
-    labels.foreach{
+    labels.foreach {
       case ((src, dest), ls) => nlg.labels.update((dest, src), ls)
     }
     nlg
@@ -270,9 +272,9 @@ class DirectedLabeledGraph[T, L](private val dgraph: DirectedGraph[T] = new Dire
   def edgeCount: Int = dgraph.edgeCount
 
   def nodes: Set[T] = dgraph.nodes
-  
+
   def succsWithLabels(src: T): Map[T, Set[L]] = {
-    successors(src).map{ dst => 
+    successors(src).map { dst =>
       dst -> labels.getOrElse((src, dst), Set[L]())
     }.toMap
   }

--- a/src/main/scala/leon/laziness/HOInferencePhase.scala
+++ b/src/main/scala/leon/laziness/HOInferencePhase.scala
@@ -128,7 +128,7 @@ object HOInferencePhase extends SimpleLeonPhase[Program, MemVerificationReport] 
       prettyPrintProgramToFile(progWOInstSpecs, ctx, "-woinst")
 
     // instrument the program for resources (note: we avoid checking preconditions again here)
-    // Note: do not inline before instrument, because inlining might change the performance properties
+    // Note: do not inline before instrument, because inlining might change the performance properties      
     val instrumenter = new MemInstrumenter(typeCorrectProg, ctx, closureFactory, funsManager)
     val instProg = HOInliningPhase(ctx, instrumenter.apply)
     if (dumpInstrumentedProgram) {

--- a/src/main/scala/leon/laziness/MemInstrumenter.scala
+++ b/src/main/scala/leon/laziness/MemInstrumenter.scala
@@ -24,7 +24,9 @@ class MemInstrumenter(p: Program, ctx: LeonContext, clFactory: ClosureFactory, f
 
   val serialInst = new SerialInstrumenter(p, instrumenterFactory, Some(exprInstFactory))
 
-  def apply: Program = serialInst.apply
+  def apply: Program = {
+    serialInst.apply
+  }
 
   class MemExprInstrumenter(ictx: InstruContext) extends ExprInstrumenter(ictx: InstruContext) {
 
@@ -61,7 +63,7 @@ class MemInstrumenter(p: Program, ctx: LeonContext, clFactory: ClosureFactory, f
             val instId = FreshIdentifier("instd", instExpr.getType, true)
             val instExprs = instrumenters map { m =>
               val hitCost = InfiniteIntegerLiteral(costOfMemoization(m.inst))
-              val missCost = m.missCost() 
+              val missCost = m.missCost()
               IfExpr(ElementOfSet(cc, stExpr), hitCost,
                 Plus(missCost, selectInst(instId.toVariable, m.inst)))
             }
@@ -132,7 +134,7 @@ class MemInstrumenter(p: Program, ctx: LeonContext, clFactory: ClosureFactory, f
     def costOf(e: Expr)(implicit currFun: FunDef): Int = {
       val cost = e match {
         case CaseClass(cct, _) if isMemoClosure(cct.root) => 0
-        case CaseClass(_, _) => 1 
+        case CaseClass(_, _) => 1
         case _ => 0
       }
       cost


### PR DESCRIPTION
This adds some inlining annotation to Leon's `Option` in order to make methods such as `map` usable within GenC. It also implements `Option.get` slightly differently for optimisation reason (probably negligible though).