### PR TITLE
Support for a new bit-vector type: Byte

### DIFF
--- a/src/main/scala/leon/codegen/CompilationUnit.scala
+++ b/src/main/scala/leon/codegen/CompilationUnit.scala
@@ -185,6 +185,9 @@ class CompilationUnit(val ctx: LeonContext,
     * reflection needs this anyway.
     */
   def valueToJVM(e: Expr)(implicit monitor: Monitor): AnyRef = e match {
+    case ByteLiteral(v) =>
+      new java.lang.Byte(v)
+
     case IntLiteral(v) =>
       new java.lang.Integer(v)
 
@@ -202,7 +205,7 @@ class CompilationUnit(val ctx: LeonContext,
 
     case FractionalLiteral(n, d) =>
       new runtime.Rational(n.toString, d.toString)
-      
+
     case StringLiteral(v) =>
       new java.lang.String(v)
 
@@ -322,6 +325,9 @@ class CompilationUnit(val ctx: LeonContext,
 
   /** Translates JVM objects back to Leon values of the appropriate type */
   def jvmToValue(e: AnyRef, tpe: TypeTree): Expr = (e, tpe) match {
+    case (b: java.lang.Byte, Int8Type) =>
+      ByteLiteral(b.toByte)
+
     case (i: Integer, Int32Type) =>
       IntLiteral(i.toInt)
 

--- a/src/main/scala/leon/evaluators/CodeGenEvaluator.scala
+++ b/src/main/scala/leon/evaluators/CodeGenEvaluator.scala
@@ -40,12 +40,12 @@ class CodeGenEvaluator(ctx: LeonContext, val unit: CompilationUnit) extends Eval
   }
 
   def eval(expression: Expr, model: solvers.Model) : EvaluationResult = {
-    compile(expression, model.toSeq.map(_._1)).map { e => 
+    compile(expression, model.toSeq.map(_._1)).map { e =>
       ctx.timers.evaluators.codegen.runtime.start()
       val res = e(model)
       ctx.timers.evaluators.codegen.runtime.stop()
       res
-    }.getOrElse(EvaluationResults.EvaluatorError("Couldn't compile expression."))
+    }.getOrElse(EvaluationResults.EvaluatorError(s"Couldn't compile expression $expression"))
   }
 
   override def compile(expression: Expr, args: Seq[Identifier]) : Option[solvers.Model=>EvaluationResult] = {

--- a/src/main/scala/leon/evaluators/RecursiveEvaluator.scala
+++ b/src/main/scala/leon/evaluators/RecursiveEvaluator.scala
@@ -46,7 +46,7 @@ abstract class RecursiveEvaluator(ctx: LeonContext, prog: Program, val bank: Eva
     def unapply(expr: Expr)(implicit rctx: RC, gctx: GC): Option[Expr] = expr match {
     case FunctionInvocation(TypedFunDef(fd, Nil), Seq(input)) if fd == program.library.escape.get =>
        e(input) match {
-         case StringLiteral(s) => 
+         case StringLiteral(s) =>
            Some(StringLiteral(StringEscapeUtils.escapeJava(s)))
          case _ => throw EvalError(typeErrorMsg(input, StringType))
        }
@@ -59,7 +59,7 @@ abstract class RecursiveEvaluator(ctx: LeonContext, prog: Program, val bank: Eva
       println(s"betweenkv_str = $betweenkv_str")
       val mp_map = e(mp) match { case FiniteMap(theMap, keyType, valueType) => theMap case _ => throw EvalError(typeErrorMsg(mp, MapType(ta, tb))) }
       println(s"mp_map = $mp_map")
-      
+
       val res = mp_map.map{ case (k, v) =>
         (e(application(fk, Seq(k))) match { case StringLiteral(s) => s case _ => throw EvalError(typeErrorMsg(k, StringType)) }) +
         inkv_str +
@@ -70,33 +70,33 @@ abstract class RecursiveEvaluator(ctx: LeonContext, prog: Program, val bank: Eva
             (e(application(fv, Seq(v))) match { case StringLiteral(s) => s case _ => throw EvalError(typeErrorMsg(k, StringType)) })
           case _ => throw EvalError(typeErrorMsg(v, program.library.Some.get.typed(Seq(tb))))
         })}.toList.sorted.mkString(betweenkv_str)
-      
+
       Some(StringLiteral(res))
-        
+
     case FunctionInvocation(TypedFunDef(fd, Seq(ta)), Seq(mp, inf, f)) if fd == program.library.setMkString.get =>
       val inf_str = e(inf) match { case StringLiteral(s) => s case _ => throw EvalError(typeErrorMsg(inf, StringType)) }
       val mp_set = e(mp) match { case FiniteSet(elems, valueType) => elems case _ => throw EvalError(typeErrorMsg(mp, SetType(ta))) }
-      
+
       val res = mp_set.map{ case v =>
         e(application(f, Seq(v))) match { case StringLiteral(s) => s case _ => throw EvalError(typeErrorMsg(v, StringType)) } }.toList.sorted.mkString(inf_str)
-      
+
       Some(StringLiteral(res))
-        
+
     case FunctionInvocation(TypedFunDef(fd, Seq(ta)), Seq(mp, inf, f)) if fd == program.library.bagMkString.get =>
       val inf_str = e(inf) match { case StringLiteral(s) => s case _ => throw EvalError(typeErrorMsg(inf, StringType)) }
       val mp_bag = e(mp) match { case FiniteBag(elems, valueType) => elems case _ => throw EvalError(typeErrorMsg(mp, SetType(ta))) }
-      
+
       val res = mp_bag.flatMap{ case (k, v) =>
         val fk = (e(application(f, Seq(k))) match { case StringLiteral(s) => s case _ => throw EvalError(typeErrorMsg(k, StringType)) })
         val times = (e(v)) match { case InfiniteIntegerLiteral(i) => i case _ => throw EvalError(typeErrorMsg(k, IntegerType)) }
         List.range(1, times.toString.toInt).map(_ => fk)
       }.toList.sorted.mkString(inf_str)
-        
+
       Some(StringLiteral(res))
     case _ => None
     }
   }
-  
+
   protected[evaluators] def e(expr: Expr)(implicit rctx: RC, gctx: GC): Expr = expr match {
     case Variable(id) =>
       rctx.mappings.get(id) match {
@@ -308,7 +308,7 @@ abstract class RecursiveEvaluator(ctx: LeonContext, prog: Program, val bank: Eva
 
     case RealMinus(l,r) =>
       e(RealPlus(l, RealUMinus(r)))
-      
+
     case StringConcat(l, r) =>
       (e(l), e(r)) match {
         case (StringLiteral(i1), StringLiteral(i2)) => StringLiteral(i1 + i2)
@@ -336,7 +336,7 @@ abstract class RecursiveEvaluator(ctx: LeonContext, prog: Program, val bank: Eva
       case IntLiteral(i) => StringLiteral(i.toString)
       case res =>  throw EvalError(typeErrorMsg(res, Int32Type))
     }
-    case CharToString(a) => 
+    case CharToString(a) =>
       e(a) match {
         case CharLiteral(i) => StringLiteral(i.toString)
         case res =>  throw EvalError(typeErrorMsg(res, CharType))
@@ -352,6 +352,18 @@ abstract class RecursiveEvaluator(ctx: LeonContext, prog: Program, val bank: Eva
     case RealToString(a) => e(a) match {
         case FractionalLiteral(n, d) => StringLiteral(n.toString + "/" + d.toString)
         case res =>  throw EvalError(typeErrorMsg(res, RealType))
+      }
+
+    case BVWideningCast(a, Int32Type) =>
+      e(a) match {
+        case ByteLiteral(b) => IntLiteral(b.toInt)
+        case x => throw EvalError(s"Expected an integral type (e.g. Int8Type) but got $x of type ${x.getType}")
+      }
+
+    case BVNarrowingCast(a, Int8Type) =>
+      e(a) match {
+        case IntLiteral(i) => ByteLiteral(i.toByte)
+        case x => throw EvalError(s"Expected an integral type (e.g. Int32Type) but got $x of type ${x.getType}")
       }
 
     case BVPlus(l,r) =>

--- a/src/main/scala/leon/evaluators/StreamEvaluator.scala
+++ b/src/main/scala/leon/evaluators/StreamEvaluator.scala
@@ -463,6 +463,10 @@ class StreamEvaluator(ctx: LeonContext, prog: Program)
       if (rn != 0) normalizeFraction(FractionalLiteral(ln * rd, ld * rn))
       else throw RuntimeError("Division by 0.")
 
+    case (BVWideningCast(_, Int32Type), Seq(ByteLiteral(b))) => IntLiteral(b.toInt)
+
+    case (BVNarrowingCast(_, Int8Type), Seq(IntLiteral(i))) => ByteLiteral(i.toByte)
+
     case (BVPlus(_, _), Seq(IntLiteral(i1), IntLiteral(i2))) =>
       IntLiteral(i1 + i2)
 
@@ -630,7 +634,7 @@ class StreamEvaluator(ctx: LeonContext, prog: Program)
       IsTyped(FiniteBag(els2, _), BagType(tpe2))
     )) =>
       FiniteBag(
-        els1.flatMap { case (k, e) => 
+        els1.flatMap { case (k, e) =>
           val res = (e, els2.getOrElse(k, InfiniteIntegerLiteral(0))) match {
             case (InfiniteIntegerLiteral(i1), InfiniteIntegerLiteral(i2)) => i1 min i2
             case (l, r) => throw EvalError(typeErrorMsg(l, IntegerType))

--- a/src/main/scala/leon/frontends/scalac/ASTExtractors.scala
+++ b/src/main/scala/leon/frontends/scalac/ASTExtractors.scala
@@ -848,16 +848,16 @@ trait ASTExtractors {
                Apply(
                  TypeApply(
                    Select(
-                     Apply(ExSelected("scala", "Predef", s), Seq(lhs)), 
+                     Apply(ExSelected("scala", "Predef", s), Seq(lhs)),
                      n
-                   ), 
+                   ),
                    _
-                 ), 
+                 ),
                  Seq(index, value)
                ),
                List(Apply(_, _))
-             ) if (s.toString contains "Array") && 
-                  (n.toString == "updated") => 
+             ) if (s.toString contains "Array") &&
+                  (n.toString == "updated") =>
           Some((lhs, index, value))
         case Apply(
                Apply(
@@ -867,12 +867,12 @@ trait ASTExtractors {
                      n
                    ),
                    _
-                 ), 
+                 ),
                  Seq(index, value)
                ),
                List(Apply(_, _))
-             ) if (s.toString contains "Array") && 
-                  (n.toString == "updated") => 
+             ) if (s.toString contains "Array") &&
+                  (n.toString == "updated") =>
           Some((lhs, index, value))
         case _ => None
       }
@@ -1030,9 +1030,16 @@ trait ASTExtractors {
       }
     }
 
-    object ExInt32Literal {
+    // Extract any kind of integer literal
+    //
+    // NOTE Because extraction happens after typechecking, expressions such as
+    //      val b: Byte = 128 // out of range
+    //      are not possible. It is therefore okay to lose the actual type of the literal.
+    //
+    // TODO Add support for more integer types
+    object ExIntLiteral {
       def unapply(tree: Literal): Option[Int] = tree match {
-        case Literal(c @ Constant(i)) if c.tpe == IntClass.tpe => Some(c.intValue)
+        case Literal(c @ Constant(i)) if Set(ByteTpe, IntTpe) contains c.tpe => Some(c.intValue)
         case _ => None
       }
     }

--- a/src/main/scala/leon/frontends/scalac/ASTExtractors.scala
+++ b/src/main/scala/leon/frontends/scalac/ASTExtractors.scala
@@ -1032,16 +1032,16 @@ trait ASTExtractors {
       }
     }
 
-    // Extract any kind of integer literal
-    //
-    // NOTE Because extraction happens after typechecking, expressions such as
-    //      val b: Byte = 128 // out of range
-    //      are not possible. It is therefore okay to lose the actual type of the literal.
-    //
-    // TODO Add support for more integer types
+    object ExByteLiteral {
+      def unapply(tree: Literal): Option[Byte] = tree match {
+        case Literal(c @ Constant(i)) if c.tpe == ByteTpe => Some(c.byteValue)
+        case _ => None
+      }
+    }
+
     object ExIntLiteral {
       def unapply(tree: Literal): Option[Int] = tree match {
-        case Literal(c @ Constant(i)) if integralTypes contains c.tpe => Some(c.intValue)
+        case Literal(c @ Constant(i)) if c.tpe == IntTpe => Some(c.intValue)
         case _ => None
       }
     }

--- a/src/main/scala/leon/frontends/scalac/ASTExtractors.scala
+++ b/src/main/scala/leon/frontends/scalac/ASTExtractors.scala
@@ -36,6 +36,8 @@ trait ASTExtractors {
     }).toMap
   }
 
+  private val integralTypes = Set(ByteTpe, IntTpe)
+
   protected lazy val tuple2Sym          = classFromName("scala.Tuple2")
   protected lazy val tuple3Sym          = classFromName("scala.Tuple3")
   protected lazy val tuple4Sym          = classFromName("scala.Tuple4")
@@ -110,9 +112,9 @@ trait ASTExtractors {
 
   def isArrayClassSym(sym: Symbol): Boolean = sym == arraySym
 
-  def hasIntType(t : Tree) = {
+  def hasIntegralType(t : Tree) = {
    val tpe = t.tpe.widen
-   tpe =:= IntClass.tpe
+   integralTypes contains tpe
   }
 
   def hasBigIntType(t : Tree) = isBigIntSym(t.tpe.typeSymbol)
@@ -1039,7 +1041,7 @@ trait ASTExtractors {
     // TODO Add support for more integer types
     object ExIntLiteral {
       def unapply(tree: Literal): Option[Int] = tree match {
-        case Literal(c @ Constant(i)) if Set(ByteTpe, IntTpe) contains c.tpe => Some(c.intValue)
+        case Literal(c @ Constant(i)) if integralTypes contains c.tpe => Some(c.intValue)
         case _ => None
       }
     }
@@ -1149,14 +1151,14 @@ trait ASTExtractors {
 
     object ExBVUMinus {
       def unapply(tree: Select): Option[Tree] = tree match {
-        case Select(t, n) if n == nme.UNARY_- && hasIntType(t) => Some(t)
+        case Select(t, n) if n == nme.UNARY_- && hasIntegralType(t) => Some(t)
         case _ => None
       }
     }
 
     object ExBVNot {
       def unapply(tree: Select): Option[Tree] = tree match {
-        case Select(t, n) if n == nme.UNARY_~ && hasIntType(t) => Some(t)
+        case Select(t, n) if n == nme.UNARY_~ && hasIntegralType(t) => Some(t)
         case _ => None
       }
     }

--- a/src/main/scala/leon/frontends/scalac/CodeExtraction.scala
+++ b/src/main/scala/leon/frontends/scalac/CodeExtraction.scala
@@ -1675,8 +1675,22 @@ trait CodeExtraction extends ASTExtractors {
         case ExNot(e)        => Not(extractTree(e))
         case ExUMinus(e)     => UMinus(extractTree(e))
         case ExRealUMinus(e) => RealUMinus(extractTree(e))
-        case ExBVUMinus(e)   => BVUMinus(extractTree(e))
-        case ExBVNot(e)      => BVNot(extractTree(e))
+
+        case ExBVUMinus(e) =>
+          val re = extractTree(e)
+          re match {
+            case IsTyped(re, Int8Type) => BVUMinus(BVWideningCast(re, Int32Type))
+            case IsTyped(re, Int32Type) => BVUMinus(re)
+            case _ => outOfSubsetError(tr, "Unexpected bit-vector length")
+          }
+
+        case ExBVNot(e) =>
+          val re = extractTree(e)
+          re match {
+            case IsTyped(re, Int8Type) => BVNot(BVWideningCast(re, Int32Type))
+            case IsTyped(re, Int32Type) => BVNot(re)
+            case _ => outOfSubsetError(tr, "Unexpected bit-vector length")
+          }
 
         case ExNotEquals(l, r) =>
           val rl = extractTree(l)

--- a/src/main/scala/leon/frontends/scalac/CodeExtraction.scala
+++ b/src/main/scala/leon/frontends/scalac/CodeExtraction.scala
@@ -1916,6 +1916,20 @@ trait CodeExtraction extends ASTExtractors {
             case (IsTyped(a1, RealType), "<=", List(IsTyped(a2, RealType))) =>
               LessEquals(a1, a2)
 
+            // Byte methods
+            // TODO add more of those
+
+            case (IsTyped(a1, Int8Type), "%", List(IsTyped(a2, Int8Type))) =>
+              BVRemainder(a1, a2)
+            case (IsTyped(a1, Int8Type), "%", List(IsTyped(a2, Int32Type))) =>
+              BVRemainder(a1, a2)
+
+            case (IsTyped(a1, Int8Type), ">", List(IsTyped(a2, Int8Type))) =>
+              GreaterThan(a1, a2)
+            case (IsTyped(a1, Int8Type), ">", List(IsTyped(a2, Int32Type))) =>
+              GreaterThan(a1, a2)
+
+
             // Int methods
             case (IsTyped(a1, Int32Type), "+", List(IsTyped(a2, Int32Type))) =>
               BVPlus(a1, a2)
@@ -1942,6 +1956,8 @@ trait CodeExtraction extends ASTExtractors {
               BVLShiftRight(a1, a2)
 
             case (IsTyped(a1, Int32Type), ">", List(IsTyped(a2, Int32Type))) =>
+              GreaterThan(a1, a2)
+            case (IsTyped(a1, Int8Type), ">", List(IsTyped(a2, Int8Type))) =>
               GreaterThan(a1, a2)
             case (IsTyped(a1, Int32Type), ">=", List(IsTyped(a2, Int32Type))) =>
               GreaterEquals(a1, a2)

--- a/src/main/scala/leon/frontends/scalac/CodeExtraction.scala
+++ b/src/main/scala/leon/frontends/scalac/CodeExtraction.scala
@@ -2100,19 +2100,19 @@ trait CodeExtraction extends ASTExtractors {
     }
 
     private def extractType(tpt: Type)(implicit dctx: DefContext, pos: Position): LeonType = tpt match {
-      case tpe if tpe == CharClass.tpe =>
+      case CharTpe =>
         CharType
 
-      case tpe if tpe == IntClass.tpe =>
+      case IntTpe =>
         Int32Type
 
-      case tpe if tpe == BooleanClass.tpe =>
+      case BooleanTpe =>
         BooleanType
 
-      case tpe if tpe == UnitClass.tpe =>
+      case UnitTpe =>
         UnitType
 
-      case tpe if tpe == NothingClass.tpe =>
+      case NothingTpe =>
         Untyped
 
       case ct: ConstantType =>

--- a/src/main/scala/leon/frontends/scalac/CodeExtraction.scala
+++ b/src/main/scala/leon/frontends/scalac/CodeExtraction.scala
@@ -1110,6 +1110,7 @@ trait CodeExtraction extends ASTExtractors {
         val lit = InfiniteIntegerLiteral(BigInt(n.value.stringValue))
         (LiteralPattern(binder, lit), dctx)
 
+      case ExByteLiteral(b)    => (LiteralPattern(binder, ByteLiteral(b)),    dctx)
       case ExIntLiteral(i)     => (LiteralPattern(binder, IntLiteral(i)),     dctx)
       case ExBooleanLiteral(b) => (LiteralPattern(binder, BooleanLiteral(b)), dctx)
       case ExUnitLiteral()     => (LiteralPattern(binder, UnitLiteral()),     dctx)
@@ -1520,6 +1521,9 @@ trait CodeExtraction extends ASTExtractors {
             case _ =>
               outOfSubsetError(tr, "Real not build from literals")
           }
+
+        case ExByteLiteral(v) =>
+          ByteLiteral(v)
 
         case ExIntLiteral(v) =>
           IntLiteral(v)

--- a/src/main/scala/leon/frontends/scalac/CodeExtraction.scala
+++ b/src/main/scala/leon/frontends/scalac/CodeExtraction.scala
@@ -1917,18 +1917,80 @@ trait CodeExtraction extends ASTExtractors {
               LessEquals(a1, a2)
 
             // Byte methods
-            // TODO add more of those
+            case (IsTyped(a1, Int8Type), "+", List(IsTyped(a2, Int8Type))) =>
+              BVPlus(a1, a2)
+            case (IsTyped(a1, Int8Type), "+", List(IsTyped(a2, Int32Type))) =>
+              BVPlus(a1, a2)
+
+            case (IsTyped(a1, Int8Type), "-", List(IsTyped(a2, Int8Type))) =>
+              BVMinus(a1, a2)
+            case (IsTyped(a1, Int8Type), "-", List(IsTyped(a2, Int32Type))) =>
+              BVMinus(a1, a2)
+
+            case (IsTyped(a1, Int8Type), "*", List(IsTyped(a2, Int8Type))) =>
+              BVTimes(a1, a2)
+            case (IsTyped(a1, Int8Type), "*", List(IsTyped(a2, Int32Type))) =>
+              BVTimes(a1, a2)
 
             case (IsTyped(a1, Int8Type), "%", List(IsTyped(a2, Int8Type))) =>
               BVRemainder(a1, a2)
             case (IsTyped(a1, Int8Type), "%", List(IsTyped(a2, Int32Type))) =>
               BVRemainder(a1, a2)
 
+            case (IsTyped(a1, Int8Type), "/", List(IsTyped(a2, Int8Type))) =>
+              BVDivision(a1, a2)
+            case (IsTyped(a1, Int8Type), "/", List(IsTyped(a2, Int32Type))) =>
+              BVDivision(a1, a2)
+
+            case (IsTyped(a1, Int8Type), "|", List(IsTyped(a2, Int8Type))) =>
+              BVOr(a1, a2)
+            case (IsTyped(a1, Int8Type), "|", List(IsTyped(a2, Int32Type))) =>
+              BVOr(a1, a2)
+
+            case (IsTyped(a1, Int8Type), "&", List(IsTyped(a2, Int8Type))) =>
+              BVAnd(a1, a2)
+            case (IsTyped(a1, Int8Type), "&", List(IsTyped(a2, Int32Type))) =>
+              BVAnd(a1, a2)
+
+            case (IsTyped(a1, Int8Type), "^", List(IsTyped(a2, Int8Type))) =>
+              BVXOr(a1, a2)
+            case (IsTyped(a1, Int8Type), "^", List(IsTyped(a2, Int32Type))) =>
+              BVXOr(a1, a2)
+
+            case (IsTyped(a1, Int8Type), "<<", List(IsTyped(a2, Int8Type))) =>
+              BVShiftLeft(a1, a2)
+            case (IsTyped(a1, Int8Type), "<<", List(IsTyped(a2, Int32Type))) =>
+              BVShiftLeft(a1, a2)
+
+            case (IsTyped(a1, Int8Type), ">>", List(IsTyped(a2, Int8Type))) =>
+              BVAShiftRight(a1, a2)
+            case (IsTyped(a1, Int8Type), ">>", List(IsTyped(a2, Int32Type))) =>
+              BVAShiftRight(a1, a2)
+
+            case (IsTyped(a1, Int8Type), ">>>", List(IsTyped(a2, Int8Type))) =>
+              BVLShiftRight(a1, a2)
+            case (IsTyped(a1, Int8Type), ">>>", List(IsTyped(a2, Int32Type))) =>
+              BVLShiftRight(a1, a2)
+
             case (IsTyped(a1, Int8Type), ">", List(IsTyped(a2, Int8Type))) =>
               GreaterThan(a1, a2)
             case (IsTyped(a1, Int8Type), ">", List(IsTyped(a2, Int32Type))) =>
               GreaterThan(a1, a2)
 
+            case (IsTyped(a1, Int8Type), ">=", List(IsTyped(a2, Int8Type))) =>
+              GreaterEquals(a1, a2)
+            case (IsTyped(a1, Int8Type), ">=", List(IsTyped(a2, Int32Type))) =>
+              GreaterEquals(a1, a2)
+
+            case (IsTyped(a1, Int8Type), "<", List(IsTyped(a2, Int8Type))) =>
+              LessThan(a1, a2)
+            case (IsTyped(a1, Int8Type), "<", List(IsTyped(a2, Int32Type))) =>
+              LessThan(a1, a2)
+
+            case (IsTyped(a1, Int8Type), "<=", List(IsTyped(a2, Int8Type))) =>
+              LessEquals(a1, a2)
+            case (IsTyped(a1, Int8Type), "<=", List(IsTyped(a2, Int32Type))) =>
+              LessEquals(a1, a2)
 
             // Int methods
             case (IsTyped(a1, Int32Type), "+", List(IsTyped(a2, Int32Type))) =>
@@ -1956,8 +2018,6 @@ trait CodeExtraction extends ASTExtractors {
               BVLShiftRight(a1, a2)
 
             case (IsTyped(a1, Int32Type), ">", List(IsTyped(a2, Int32Type))) =>
-              GreaterThan(a1, a2)
-            case (IsTyped(a1, Int8Type), ">", List(IsTyped(a2, Int8Type))) =>
               GreaterThan(a1, a2)
             case (IsTyped(a1, Int32Type), ">=", List(IsTyped(a2, Int32Type))) =>
               GreaterEquals(a1, a2)

--- a/src/main/scala/leon/frontends/scalac/CodeExtraction.scala
+++ b/src/main/scala/leon/frontends/scalac/CodeExtraction.scala
@@ -1993,36 +1993,66 @@ trait CodeExtraction extends ASTExtractors {
               LessEquals(BVWideningCast(a1, Int32Type), a2)
 
             // Int methods
+            case (IsTyped(a1, Int32Type), "+", List(IsTyped(a2, Int8Type))) =>
+              BVPlus(a1, BVWideningCast(a2, Int32Type))
             case (IsTyped(a1, Int32Type), "+", List(IsTyped(a2, Int32Type))) =>
               BVPlus(a1, a2)
+            case (IsTyped(a1, Int32Type), "-", List(IsTyped(a2, Int8Type))) =>
+              BVMinus(a1, BVWideningCast(a2, Int32Type))
             case (IsTyped(a1, Int32Type), "-", List(IsTyped(a2, Int32Type))) =>
               BVMinus(a1, a2)
+            case (IsTyped(a1, Int32Type), "*", List(IsTyped(a2, Int8Type))) =>
+              BVTimes(a1, BVWideningCast(a2, Int32Type))
             case (IsTyped(a1, Int32Type), "*", List(IsTyped(a2, Int32Type))) =>
               BVTimes(a1, a2)
+            case (IsTyped(a1, Int32Type), "%", List(IsTyped(a2, Int8Type))) =>
+              BVRemainder(a1, BVWideningCast(a2, Int32Type))
             case (IsTyped(a1, Int32Type), "%", List(IsTyped(a2, Int32Type))) =>
               BVRemainder(a1, a2)
+            case (IsTyped(a1, Int32Type), "/", List(IsTyped(a2, Int8Type))) =>
+              BVDivision(a1, BVWideningCast(a2, Int32Type))
             case (IsTyped(a1, Int32Type), "/", List(IsTyped(a2, Int32Type))) =>
               BVDivision(a1, a2)
 
+            case (IsTyped(a1, Int32Type), "|", List(IsTyped(a2, Int8Type))) =>
+              BVOr(a1, BVWideningCast(a2, Int32Type))
             case (IsTyped(a1, Int32Type), "|", List(IsTyped(a2, Int32Type))) =>
               BVOr(a1, a2)
+            case (IsTyped(a1, Int32Type), "&", List(IsTyped(a2, Int8Type))) =>
+              BVAnd(a1, BVWideningCast(a2, Int32Type))
             case (IsTyped(a1, Int32Type), "&", List(IsTyped(a2, Int32Type))) =>
               BVAnd(a1, a2)
+            case (IsTyped(a1, Int32Type), "^", List(IsTyped(a2, Int8Type))) =>
+              BVXOr(a1, BVWideningCast(a2, Int32Type))
             case (IsTyped(a1, Int32Type), "^", List(IsTyped(a2, Int32Type))) =>
               BVXOr(a1, a2)
+            case (IsTyped(a1, Int32Type), "<<", List(IsTyped(a2, Int8Type))) =>
+              BVShiftLeft(a1, BVWideningCast(a2, Int32Type))
             case (IsTyped(a1, Int32Type), "<<", List(IsTyped(a2, Int32Type))) =>
               BVShiftLeft(a1, a2)
+            case (IsTyped(a1, Int32Type), ">>", List(IsTyped(a2, Int8Type))) =>
+              BVAShiftRight(a1, BVWideningCast(a2, Int32Type))
             case (IsTyped(a1, Int32Type), ">>", List(IsTyped(a2, Int32Type))) =>
               BVAShiftRight(a1, a2)
+            case (IsTyped(a1, Int32Type), ">>>", List(IsTyped(a2, Int8Type))) =>
+              BVLShiftRight(a1, BVWideningCast(a2, Int32Type))
             case (IsTyped(a1, Int32Type), ">>>", List(IsTyped(a2, Int32Type))) =>
               BVLShiftRight(a1, a2)
 
+            case (IsTyped(a1, Int32Type), ">", List(IsTyped(a2, Int8Type))) =>
+              GreaterThan(a1, BVWideningCast(a2, Int32Type))
             case (IsTyped(a1, Int32Type), ">", List(IsTyped(a2, Int32Type))) =>
               GreaterThan(a1, a2)
+            case (IsTyped(a1, Int32Type), ">=", List(IsTyped(a2, Int8Type))) =>
+              GreaterEquals(a1, BVWideningCast(a2, Int32Type))
             case (IsTyped(a1, Int32Type), ">=", List(IsTyped(a2, Int32Type))) =>
               GreaterEquals(a1, a2)
+            case (IsTyped(a1, Int32Type), "<", List(IsTyped(a2, Int8Type))) =>
+              LessThan(a1, BVWideningCast(a2, Int32Type))
             case (IsTyped(a1, Int32Type), "<", List(IsTyped(a2, Int32Type))) =>
               LessThan(a1, a2)
+            case (IsTyped(a1, Int32Type), "<=", List(IsTyped(a2, Int8Type))) =>
+              LessEquals(a1, BVWideningCast(a2, Int32Type))
             case (IsTyped(a1, Int32Type), "<=", List(IsTyped(a2, Int32Type))) =>
               LessEquals(a1, a2)
 

--- a/src/main/scala/leon/frontends/scalac/CodeExtraction.scala
+++ b/src/main/scala/leon/frontends/scalac/CodeExtraction.scala
@@ -1918,79 +1918,79 @@ trait CodeExtraction extends ASTExtractors {
 
             // Byte methods
             case (IsTyped(a1, Int8Type), "+", List(IsTyped(a2, Int8Type))) =>
-              BVPlus(a1, a2)
+              BVPlus(BVWideningCast(a1, Int32Type), BVWideningCast(a2, Int32Type))
             case (IsTyped(a1, Int8Type), "+", List(IsTyped(a2, Int32Type))) =>
-              BVPlus(a1, a2)
+              BVPlus(BVWideningCast(a1, Int32Type), a2)
 
             case (IsTyped(a1, Int8Type), "-", List(IsTyped(a2, Int8Type))) =>
-              BVMinus(a1, a2)
+              BVMinus(BVWideningCast(a1, Int32Type), BVWideningCast(a2, Int32Type))
             case (IsTyped(a1, Int8Type), "-", List(IsTyped(a2, Int32Type))) =>
-              BVMinus(a1, a2)
+              BVMinus(BVWideningCast(a1, Int32Type), a2)
 
             case (IsTyped(a1, Int8Type), "*", List(IsTyped(a2, Int8Type))) =>
-              BVTimes(a1, a2)
+              BVTimes(BVWideningCast(a1, Int32Type), BVWideningCast(a2, Int32Type))
             case (IsTyped(a1, Int8Type), "*", List(IsTyped(a2, Int32Type))) =>
-              BVTimes(a1, a2)
+              BVTimes(BVWideningCast(a1, Int32Type), a2)
 
             case (IsTyped(a1, Int8Type), "%", List(IsTyped(a2, Int8Type))) =>
-              BVRemainder(a1, a2)
+              BVRemainder(BVWideningCast(a1, Int32Type), BVWideningCast(a2, Int32Type))
             case (IsTyped(a1, Int8Type), "%", List(IsTyped(a2, Int32Type))) =>
-              BVRemainder(a1, a2)
+              BVRemainder(BVWideningCast(a1, Int32Type), a2)
 
             case (IsTyped(a1, Int8Type), "/", List(IsTyped(a2, Int8Type))) =>
-              BVDivision(a1, a2)
+              BVDivision(BVWideningCast(a1, Int32Type), BVWideningCast(a2, Int32Type))
             case (IsTyped(a1, Int8Type), "/", List(IsTyped(a2, Int32Type))) =>
-              BVDivision(a1, a2)
+              BVDivision(BVWideningCast(a1, Int32Type), a2)
 
             case (IsTyped(a1, Int8Type), "|", List(IsTyped(a2, Int8Type))) =>
-              BVOr(a1, a2)
+              BVOr(BVWideningCast(a1, Int32Type), BVWideningCast(a2, Int32Type))
             case (IsTyped(a1, Int8Type), "|", List(IsTyped(a2, Int32Type))) =>
-              BVOr(a1, a2)
+              BVOr(BVWideningCast(a1, Int32Type), a2)
 
             case (IsTyped(a1, Int8Type), "&", List(IsTyped(a2, Int8Type))) =>
-              BVAnd(a1, a2)
+              BVAnd(BVWideningCast(a1, Int32Type), BVWideningCast(a2, Int32Type))
             case (IsTyped(a1, Int8Type), "&", List(IsTyped(a2, Int32Type))) =>
-              BVAnd(a1, a2)
+              BVAnd(BVWideningCast(a1, Int32Type), a2)
 
             case (IsTyped(a1, Int8Type), "^", List(IsTyped(a2, Int8Type))) =>
-              BVXOr(a1, a2)
+              BVXOr(BVWideningCast(a1, Int32Type), BVWideningCast(a2, Int32Type))
             case (IsTyped(a1, Int8Type), "^", List(IsTyped(a2, Int32Type))) =>
-              BVXOr(a1, a2)
+              BVXOr(BVWideningCast(a1, Int32Type), a2)
 
             case (IsTyped(a1, Int8Type), "<<", List(IsTyped(a2, Int8Type))) =>
-              BVShiftLeft(a1, a2)
+              BVShiftLeft(BVWideningCast(a1, Int32Type), BVWideningCast(a2, Int32Type))
             case (IsTyped(a1, Int8Type), "<<", List(IsTyped(a2, Int32Type))) =>
-              BVShiftLeft(a1, a2)
+              BVShiftLeft(BVWideningCast(a1, Int32Type), a2)
 
             case (IsTyped(a1, Int8Type), ">>", List(IsTyped(a2, Int8Type))) =>
-              BVAShiftRight(a1, a2)
+              BVAShiftRight(BVWideningCast(a1, Int32Type), BVWideningCast(a2, Int32Type))
             case (IsTyped(a1, Int8Type), ">>", List(IsTyped(a2, Int32Type))) =>
-              BVAShiftRight(a1, a2)
+              BVAShiftRight(BVWideningCast(a1, Int32Type), a2)
 
             case (IsTyped(a1, Int8Type), ">>>", List(IsTyped(a2, Int8Type))) =>
-              BVLShiftRight(a1, a2)
+              BVLShiftRight(BVWideningCast(a1, Int32Type), BVWideningCast(a2, Int32Type))
             case (IsTyped(a1, Int8Type), ">>>", List(IsTyped(a2, Int32Type))) =>
-              BVLShiftRight(a1, a2)
+              BVLShiftRight(BVWideningCast(a1, Int32Type), a2)
 
             case (IsTyped(a1, Int8Type), ">", List(IsTyped(a2, Int8Type))) =>
-              GreaterThan(a1, a2)
+              GreaterThan(BVWideningCast(a1, Int32Type), BVWideningCast(a2, Int32Type))
             case (IsTyped(a1, Int8Type), ">", List(IsTyped(a2, Int32Type))) =>
-              GreaterThan(a1, a2)
+              GreaterThan(BVWideningCast(a1, Int32Type), a2)
 
             case (IsTyped(a1, Int8Type), ">=", List(IsTyped(a2, Int8Type))) =>
-              GreaterEquals(a1, a2)
+              GreaterEquals(BVWideningCast(a1, Int32Type), BVWideningCast(a2, Int32Type))
             case (IsTyped(a1, Int8Type), ">=", List(IsTyped(a2, Int32Type))) =>
-              GreaterEquals(a1, a2)
+              GreaterEquals(BVWideningCast(a1, Int32Type), a2)
 
             case (IsTyped(a1, Int8Type), "<", List(IsTyped(a2, Int8Type))) =>
-              LessThan(a1, a2)
+              LessThan(BVWideningCast(a1, Int32Type), BVWideningCast(a2, Int32Type))
             case (IsTyped(a1, Int8Type), "<", List(IsTyped(a2, Int32Type))) =>
-              LessThan(a1, a2)
+              LessThan(BVWideningCast(a1, Int32Type), a2)
 
             case (IsTyped(a1, Int8Type), "<=", List(IsTyped(a2, Int8Type))) =>
-              LessEquals(a1, a2)
+              LessEquals(BVWideningCast(a1, Int32Type), BVWideningCast(a2, Int32Type))
             case (IsTyped(a1, Int8Type), "<=", List(IsTyped(a2, Int32Type))) =>
-              LessEquals(a1, a2)
+              LessEquals(BVWideningCast(a1, Int32Type), a2)
 
             // Int methods
             case (IsTyped(a1, Int32Type), "+", List(IsTyped(a2, Int32Type))) =>
@@ -2025,6 +2025,16 @@ trait CodeExtraction extends ASTExtractors {
               LessThan(a1, a2)
             case (IsTyped(a1, Int32Type), "<=", List(IsTyped(a2, Int32Type))) =>
               LessEquals(a1, a2)
+
+            // Casts
+            case (IsTyped(a, Int8Type), "toByte", List()) =>
+              a
+            case (IsTyped(a, Int8Type), "toInt", List()) =>
+              BVWideningCast(a, Int32Type)
+            case (IsTyped(a, Int32Type), "toByte", List()) =>
+              BVNarrowingCast(a, Int8Type)
+            case (IsTyped(a, Int32Type), "toInt", List()) =>
+              a
 
             // Boolean methods
             case (IsTyped(a1, BooleanType), "&&", List(IsTyped(a2, BooleanType))) =>

--- a/src/main/scala/leon/frontends/scalac/CodeExtraction.scala
+++ b/src/main/scala/leon/frontends/scalac/CodeExtraction.scala
@@ -2100,6 +2100,9 @@ trait CodeExtraction extends ASTExtractors {
     }
 
     private def extractType(tpt: Type)(implicit dctx: DefContext, pos: Position): LeonType = tpt match {
+      case ByteTpe =>
+        Int8Type
+
       case CharTpe =>
         CharType
 

--- a/src/main/scala/leon/frontends/scalac/CodeExtraction.scala
+++ b/src/main/scala/leon/frontends/scalac/CodeExtraction.scala
@@ -1110,7 +1110,7 @@ trait CodeExtraction extends ASTExtractors {
         val lit = InfiniteIntegerLiteral(BigInt(n.value.stringValue))
         (LiteralPattern(binder, lit), dctx)
 
-      case ExInt32Literal(i)   => (LiteralPattern(binder, IntLiteral(i)),     dctx)
+      case ExIntLiteral(i)     => (LiteralPattern(binder, IntLiteral(i)),     dctx)
       case ExBooleanLiteral(b) => (LiteralPattern(binder, BooleanLiteral(b)), dctx)
       case ExUnitLiteral()     => (LiteralPattern(binder, UnitLiteral()),     dctx)
       case ExStringLiteral(s)  => (LiteralPattern(binder, StringLiteral(s)),  dctx)
@@ -1521,7 +1521,7 @@ trait CodeExtraction extends ASTExtractors {
               outOfSubsetError(tr, "Real not build from literals")
           }
 
-        case ExInt32Literal(v) =>
+        case ExIntLiteral(v) =>
           IntLiteral(v)
 
         case ExBooleanLiteral(v) =>

--- a/src/main/scala/leon/purescala/Expressions.scala
+++ b/src/main/scala/leon/purescala/Expressions.scala
@@ -405,7 +405,7 @@ object Expressions {
     def isSome(scrut: Expr) = IsInstanceOf(FunctionInvocation(unapplyFun, Seq(scrut)), someType)
 
   }
-  
+
   // Extracts without taking care of the binder. (contrary to Extractos.Pattern)
   object PatternExtractor extends TreeExtractor[Pattern] {
     def unapply(e: Pattern): Option[(Seq[Pattern], (Seq[Pattern]) => Pattern)] = e match {
@@ -420,7 +420,7 @@ object Expressions {
       case _ => None
     }
   }
-  
+
   object PatternOps extends GenTreeOps[Pattern] {
     val Deconstructor = PatternExtractor
   }
@@ -611,12 +611,12 @@ object Expressions {
       else Untyped
     }
   }
-  
+
   abstract class ConverterToString(fromType: TypeTree, toType: TypeTree) extends Expr {
     def expr: Expr
     val getType = if(expr.getType == fromType) toType else Untyped
   }
-  
+
   /* String Theory */
   /** $encodingof `expr.toString` for Int32 to String */
   case class Int32ToString(expr: Expr) extends ConverterToString(Int32Type, StringType)
@@ -756,34 +756,36 @@ object Expressions {
 
 
   /* Bit-vector arithmetic */
+  // TODO if Long is supported, most getType should be updated to return Long
+  //      if one of the operand is of Long type.
   /** $encodingof `... + ...` $noteBitvector*/
   case class BVPlus(lhs: Expr, rhs: Expr) extends Expr {
-    require(lhs.getType == Int32Type && rhs.getType == Int32Type)
+    require(isBVType(lhs.getType) && isBVType(rhs.getType))
     val getType = Int32Type
   }
   /** $encodingof `... - ...` $noteBitvector*/
   case class BVMinus(lhs: Expr, rhs: Expr) extends Expr {
-    require(lhs.getType == Int32Type && rhs.getType == Int32Type)
+    require(isBVType(lhs.getType) && isBVType(rhs.getType))
     val getType = Int32Type
   }
   /** $encodingof `- ...` $noteBitvector*/
   case class BVUMinus(expr: Expr) extends Expr {
-    require(expr.getType == Int32Type)
+    require(isBVType(expr.getType))
     val getType = Int32Type
   }
   /** $encodingof `... * ...` $noteBitvector*/
   case class BVTimes(lhs: Expr, rhs: Expr) extends Expr {
-    require(lhs.getType == Int32Type && rhs.getType == Int32Type)
+    require(isBVType(lhs.getType) && isBVType(rhs.getType))
     val getType = Int32Type
   }
   /** $encodingof `... / ...` $noteBitvector*/
   case class BVDivision(lhs: Expr, rhs: Expr) extends Expr {
-    require(lhs.getType == Int32Type && rhs.getType == Int32Type)
+    require(isBVType(lhs.getType) && isBVType(rhs.getType))
     val getType = Int32Type
   }
   /** $encodingof `... % ...` $noteBitvector*/
   case class BVRemainder(lhs: Expr, rhs: Expr) extends Expr {
-    require(lhs.getType == Int32Type && rhs.getType == Int32Type)
+    require(isBVType(lhs.getType) && isBVType(rhs.getType))
     val getType = Int32Type
   }
   /** $encodingof `! ...` $noteBitvector */

--- a/src/main/scala/leon/purescala/Expressions.scala
+++ b/src/main/scala/leon/purescala/Expressions.scala
@@ -739,22 +739,18 @@ object Expressions {
   }
   /** $encodingof `... < ...`*/
   case class LessThan(lhs: Expr, rhs: Expr) extends Expr {
-    require(lhs.getType == rhs.getType)
     val getType = BooleanType
   }
   /** $encodingof `... > ...`*/
   case class GreaterThan(lhs: Expr, rhs: Expr) extends Expr {
-    require(lhs.getType == rhs.getType)
     val getType = BooleanType
   }
   /** $encodingof `... <= ...`*/
   case class LessEquals(lhs: Expr, rhs: Expr) extends Expr {
-    require(lhs.getType == rhs.getType)
     val getType = BooleanType
   }
   /** $encodingof `... >= ...`*/
   case class GreaterEquals(lhs: Expr, rhs: Expr) extends Expr {
-    require(lhs.getType == rhs.getType)
     val getType = BooleanType
   }
 

--- a/src/main/scala/leon/purescala/Expressions.scala
+++ b/src/main/scala/leon/purescala/Expressions.scala
@@ -459,6 +459,10 @@ object Expressions {
   case class CharLiteral(value: Char) extends Literal[Char] {
     val getType = CharType
   }
+  /** $encodingof a 8-bit integer literal */
+  case class ByteLiteral(value: Byte) extends Literal[Byte] {
+    val getType = Int8Type
+  }
   /** $encodingof a 32-bit integer literal */
   case class IntLiteral(value: Int) extends Literal[Int] {
     val getType = Int32Type

--- a/src/main/scala/leon/purescala/Expressions.scala
+++ b/src/main/scala/leon/purescala/Expressions.scala
@@ -826,6 +826,27 @@ object Expressions {
     val getType = lhs.getType
   }
 
+  /** TODO Doc (format???) */
+  case class BVNarrowingCast(expr: Expr, newType: BitVectorType) extends Expr {
+    require(expr.getType match {
+      case BVType(size) if size > newType.size => true
+      case _ => false
+    })
+    val getType = newType
+    val from = expr.getType.asInstanceOf[BitVectorType].size
+    val to = newType.size
+  }
+  /** TODO Doc (format???) */
+  case class BVWideningCast(expr: Expr, newType: BitVectorType) extends Expr {
+    require(expr.getType match {
+      case BVType(size) if size < newType.size => true
+      case _ => false
+    })
+    val getType = newType
+    val from = expr.getType.asInstanceOf[BitVectorType].size
+    val to = newType.size
+  }
+
 
   /* Real arithmetic */
   /** $encodingof `... + ...` $noteReal */

--- a/src/main/scala/leon/purescala/Expressions.scala
+++ b/src/main/scala/leon/purescala/Expressions.scala
@@ -739,82 +739,91 @@ object Expressions {
   }
   /** $encodingof `... < ...`*/
   case class LessThan(lhs: Expr, rhs: Expr) extends Expr {
+    require(lhs.getType == rhs.getType)
     val getType = BooleanType
   }
   /** $encodingof `... > ...`*/
   case class GreaterThan(lhs: Expr, rhs: Expr) extends Expr {
+    require(lhs.getType == rhs.getType)
     val getType = BooleanType
   }
   /** $encodingof `... <= ...`*/
   case class LessEquals(lhs: Expr, rhs: Expr) extends Expr {
+    require(lhs.getType == rhs.getType)
     val getType = BooleanType
   }
   /** $encodingof `... >= ...`*/
   case class GreaterEquals(lhs: Expr, rhs: Expr) extends Expr {
+    require(lhs.getType == rhs.getType)
     val getType = BooleanType
   }
 
 
   /* Bit-vector arithmetic */
-  // TODO if Long is supported, most getType should be updated to return Long
-  //      if one of the operand is of Long type.
   /** $encodingof `... + ...` $noteBitvector*/
   case class BVPlus(lhs: Expr, rhs: Expr) extends Expr {
-    require(isBVType(lhs.getType) && isBVType(rhs.getType))
-    val getType = Int32Type
+    require(areSameBVType(lhs.getType, rhs.getType))
+    val getType = lhs.getType
   }
   /** $encodingof `... - ...` $noteBitvector*/
   case class BVMinus(lhs: Expr, rhs: Expr) extends Expr {
-    require(isBVType(lhs.getType) && isBVType(rhs.getType))
-    val getType = Int32Type
+    require(areSameBVType(lhs.getType, rhs.getType))
+    val getType = lhs.getType
   }
   /** $encodingof `- ...` $noteBitvector*/
   case class BVUMinus(expr: Expr) extends Expr {
     require(isBVType(expr.getType))
-    val getType = Int32Type
+    val getType = expr.getType
   }
   /** $encodingof `... * ...` $noteBitvector*/
   case class BVTimes(lhs: Expr, rhs: Expr) extends Expr {
-    require(isBVType(lhs.getType) && isBVType(rhs.getType))
-    val getType = Int32Type
+    require(areSameBVType(lhs.getType, rhs.getType))
+    val getType = lhs.getType
   }
   /** $encodingof `... / ...` $noteBitvector*/
   case class BVDivision(lhs: Expr, rhs: Expr) extends Expr {
-    require(isBVType(lhs.getType) && isBVType(rhs.getType))
-    val getType = Int32Type
+    require(areSameBVType(lhs.getType, rhs.getType))
+    val getType = lhs.getType
   }
   /** $encodingof `... % ...` $noteBitvector*/
   case class BVRemainder(lhs: Expr, rhs: Expr) extends Expr {
-    require(isBVType(lhs.getType) && isBVType(rhs.getType))
-    val getType = Int32Type
+    require(areSameBVType(lhs.getType, rhs.getType))
+    val getType = lhs.getType
   }
   /** $encodingof `! ...` $noteBitvector */
   case class BVNot(expr: Expr) extends Expr {
-    val getType = Int32Type
+    require(isBVType(expr.getType))
+    val getType = expr.getType
   }
   /** $encodingof `... & ...` $noteBitvector */
   case class BVAnd(lhs: Expr, rhs: Expr) extends Expr {
-    val getType = Int32Type
+    require(areSameBVType(lhs.getType, rhs.getType))
+    val getType = lhs.getType
   }
   /** $encodingof `... | ...` $noteBitvector */
   case class BVOr(lhs: Expr, rhs: Expr) extends Expr {
-    val getType = Int32Type
+    require(areSameBVType(lhs.getType, rhs.getType))
+    val getType = lhs.getType
   }
   /** $encodingof `... ^ ...` $noteBitvector */
   case class BVXOr(lhs: Expr, rhs: Expr) extends Expr {
-    val getType = Int32Type
+    require(areSameBVType(lhs.getType, rhs.getType))
+    val getType = lhs.getType
   }
   /** $encodingof `... << ...` $noteBitvector */
   case class BVShiftLeft(lhs: Expr, rhs: Expr) extends Expr {
-    val getType = Int32Type
+    require(areSameBVType(lhs.getType, rhs.getType))
+    val getType = lhs.getType
   }
   /** $encodingof `... >> ...` $noteBitvector (arithmetic shift, sign-preserving) */
   case class BVAShiftRight(lhs: Expr, rhs: Expr) extends Expr {
-    val getType = Int32Type
+    require(areSameBVType(lhs.getType, rhs.getType))
+    val getType = lhs.getType
   }
   /** $encodingof `... >>> ...` $noteBitvector (logical shift) */
   case class BVLShiftRight(lhs: Expr, rhs: Expr) extends Expr {
-    val getType = Int32Type
+    require(areSameBVType(lhs.getType, rhs.getType))
+    val getType = lhs.getType
   }
 
 

--- a/src/main/scala/leon/purescala/PrettyPrinter.scala
+++ b/src/main/scala/leon/purescala/PrettyPrinter.scala
@@ -199,6 +199,7 @@ class PrettyPrinter(opts: PrinterOptions,
       case StringLength(expr)             => p"$expr.length"
       case StringBigLength(expr)          => p"$expr.bigLength"
 
+      case ByteLiteral(v)                 => p"$v"
       case IntLiteral(v)                  => p"$v"
       case InfiniteIntegerLiteral(v)      => p"$v"
       case FractionalLiteral(n, d) =>

--- a/src/main/scala/leon/purescala/PrettyPrinter.scala
+++ b/src/main/scala/leon/purescala/PrettyPrinter.scala
@@ -106,7 +106,7 @@ class PrettyPrinter(opts: PrinterOptions,
 
       case Require(BooleanLiteral(true), body) =>
         p"|$body"
-        
+
       case Require(pre, body) =>
         p"""|require($pre)
             |$body"""
@@ -168,7 +168,7 @@ class PrettyPrinter(opts: PrinterOptions,
               val lclass = AbstractClassType(opgm.get.library.List.get, cct.tps)
               p"$lclass($elems)"
             }
-              
+
           case None =>
             if (cct.classDef.isCaseObject) {
               p"$cct"
@@ -216,18 +216,18 @@ class PrettyPrinter(opts: PrinterOptions,
           p"$dbquote$escaped$dbquote"
         }
 
-      case ArrayForall(a, IntLiteral(0), ArrayLength(a2), pred) if a == a2 => 
+      case ArrayForall(a, IntLiteral(0), ArrayLength(a2), pred) if a == a2 =>
         p"$a.forall($pred)"
-      case ArrayForall(a, from, to, pred) => 
+      case ArrayForall(a, from, to, pred) =>
         p"$a.forall($from, $to, $pred)"
-      case BoundedForall(from, to, pred) => 
+      case BoundedForall(from, to, pred) =>
         p"forall($from, $to, $pred)"
 
-      case ArrayExists(a, IntLiteral(0), ArrayLength(a2), pred) if a == a2 => 
+      case ArrayExists(a, IntLiteral(0), ArrayLength(a2), pred) if a == a2 =>
         p"$a.exists($pred)"
-      case ArrayExists(a, from, to, pred) => 
+      case ArrayExists(a, from, to, pred) =>
         p"$a.exists($from, $to, $pred)"
-      case BoundedExists(from, to, pred) => 
+      case BoundedExists(from, to, pred) =>
         p"exists($from, $to, $pred)"
 
       case GenericValue(tp, id) => p"$tp#$id"
@@ -493,6 +493,7 @@ class PrettyPrinter(opts: PrinterOptions,
       // Types
       case Untyped               => p"<untyped>"
       case UnitType              => p"Unit"
+      case Int8Type              => p"Byte"
       case Int32Type             => p"Int"
       case IntegerType           => p"BigInt"
       case RealType              => p"Real"

--- a/src/main/scala/leon/purescala/PrettyPrinter.scala
+++ b/src/main/scala/leon/purescala/PrettyPrinter.scala
@@ -348,6 +348,10 @@ class PrettyPrinter(opts: PrinterOptions,
       case BVShiftLeft(l, r)        => optP { p"$l << $r" }
       case BVAShiftRight(l, r)      => optP { p"$l >> $r" }
       case BVLShiftRight(l, r)      => optP { p"$l >>> $r" }
+      case BVNarrowingCast(e, Int32Type) => p"$e.toInt"
+      case BVNarrowingCast(e, Int8Type)  => p"$e.toByte"
+      case BVWideningCast(e, Int32Type)  => p"$e.toInt"
+      case BVWideningCast(e, Int8Type)   => p"$e.toByte"
       case RealPlus(l, r)           => optP { p"$l + $r" }
       case RealMinus(l, r)          => optP { p"$l - $r" }
       case RealTimes(l, r)          => optP { p"$l * $r" }

--- a/src/main/scala/leon/purescala/TypeOps.scala
+++ b/src/main/scala/leon/purescala/TypeOps.scala
@@ -200,6 +200,11 @@ object TypeOps extends GenTreeOps[TypeTree] {
     case _ => false
   }
 
+  def areSameBVType(tpe1: TypeTree, tpe2: TypeTree): Boolean = (tpe1, tpe2) match {
+    case (BVType(s1), BVType(s2)) if s1 == s2 => true
+    case _ => false
+  }
+
   // Helpers for instantiateType
   private def typeParamSubst(map: Map[TypeParameter, TypeTree])(tpe: TypeTree): TypeTree = tpe match {
     case (tp: TypeParameter) => map.getOrElse(tp, tp)

--- a/src/main/scala/leon/purescala/TypeOps.scala
+++ b/src/main/scala/leon/purescala/TypeOps.scala
@@ -191,6 +191,11 @@ object TypeOps extends GenTreeOps[TypeTree] {
     case NAryType(tps, builder) => tps.exists(isParametricType)
   }
 
+  def isBVType(tpe: TypeTree): Boolean = tpe match {
+    case bv: BitVectorType => true
+    case _ => false
+  }
+
   // Helpers for instantiateType
   private def typeParamSubst(map: Map[TypeParameter, TypeTree])(tpe: TypeTree): TypeTree = tpe match {
     case (tp: TypeParameter) => map.getOrElse(tp, tp)
@@ -261,7 +266,7 @@ object TypeOps extends GenTreeOps[TypeTree] {
       }.product)
     case act: AbstractClassType =>
       val possibleChildTypes = leon.utils.fixpoint((tpes: Set[TypeTree]) => {
-        tpes.flatMap(tpe => 
+        tpes.flatMap(tpe =>
           Set(tpe) ++ (tpe match {
             case cct: CaseClassType => cct.fieldsTypes
             case act: AbstractClassType => Set(act) ++ act.knownCCDescendants

--- a/src/main/scala/leon/purescala/TypeOps.scala
+++ b/src/main/scala/leon/purescala/TypeOps.scala
@@ -107,6 +107,10 @@ object TypeOps extends GenTreeOps[TypeTree] {
           }
         }
 
+      case (bv1: BitVectorType, bv2: BitVectorType) =>
+        val largest = if (bv1.size > bv2.size) bv1 else bv2
+        Some((largest, Map.empty))
+
       case Same(t1, t2) =>
         // Only tuples are covariant
         def allowVariance = t1 match {

--- a/src/main/scala/leon/purescala/Types.scala
+++ b/src/main/scala/leon/purescala/Types.scala
@@ -52,6 +52,13 @@ object Types {
   case object Int32Type extends BitVectorType(32)
   case object StringType extends TypeTree
 
+  object BVType {
+    def unapply(typ: TypeTree): Option[Int] = typ match {
+      case bv: BitVectorType => Some(bv.size)
+      case _ => None
+    }
+  }
+
   class TypeParameter private (name: String) extends TypeTree {
     val id = FreshIdentifier(name, this)
 

--- a/src/main/scala/leon/purescala/Types.scala
+++ b/src/main/scala/leon/purescala/Types.scala
@@ -32,10 +32,10 @@ object Types {
 
     // Checks whether the subtypes of this type contain Untyped,
     // and if so sets this to Untyped.
-    // Assumes the subtypes are correctly formed, so it does not descend 
+    // Assumes the subtypes are correctly formed, so it does not descend
     // deep into the TypeTree.
     def unveilUntyped: TypeTree = this match {
-      case NAryType(tps, _) => 
+      case NAryType(tps, _) =>
         if (tps contains Untyped) Untyped else this
     }
   }
@@ -48,6 +48,7 @@ object Types {
   case object RealType extends TypeTree
 
   abstract class BitVectorType(val size: Int) extends TypeTree
+  case object Int8Type extends BitVectorType(8)
   case object Int32Type extends BitVectorType(32)
   case object StringType extends TypeTree
 
@@ -80,8 +81,8 @@ object Types {
     def fresh(name: String) = new TypeParameter(name)
   }
 
-  /* 
-   * If you are not sure about the requirement, 
+  /*
+   * If you are not sure about the requirement,
    * you should use tupleTypeWrap in purescala.Constructors
    */
   case class TupleType(bases: Seq[TypeTree]) extends TypeTree {
@@ -173,7 +174,7 @@ object Types {
       case _ => None
     }
   }
-  
+
   def optionToType(tp: Option[TypeTree]) = tp getOrElse Untyped
 
 }

--- a/src/main/scala/leon/solvers/smtlib/SMTLIBTarget.scala
+++ b/src/main/scala/leon/solvers/smtlib/SMTLIBTarget.scala
@@ -509,11 +509,14 @@ trait SMTLIBTarget extends Interruptible {
 
       case Not(u)          => Core.Not(toSMT(u))
       case UMinus(u)       => Ints.Neg(toSMT(u))
-      case BVUMinus(u)     => FixedSizeBitVectors.Neg(toSMT(u))
-      case BVNot(u)        => FixedSizeBitVectors.Not(toSMT(u))
+      case BVUMinus(u)     => FixedSizeBitVectors.Neg(extendTo32(toSMT(u), u))
+      case BVNot(u)        => FixedSizeBitVectors.Not(extendTo32(toSMT(u), u))
       case Assert(a, _, b) => toSMT(IfExpr(a, b, Error(b.getType, "assertion failed")))
 
-      case Equals(a, b)    => Core.Equals(toSMT(a), toSMT(b))
+      case Equals(a, b)    =>
+        if (isBVType(a.getType)) Core.Equals(extendTo32(toSMT(a), a), extendTo32(toSMT(b), b))
+        else Core.Equals(toSMT(a), toSMT(b))
+
       case Implies(a, b)   => Core.Implies(toSMT(a), toSMT(b))
       case Plus(a, b)      => Ints.Add(toSMT(a), toSMT(b))
       case Minus(a, b)     => Ints.Sub(toSMT(a), toSMT(b))
@@ -535,40 +538,41 @@ trait SMTLIBTarget extends Interruptible {
         Ints.Mod(toSMT(a), toSMT(b))
       }
       case LessThan(a, b) => a.getType match {
-        case Int32Type   => FixedSizeBitVectors.SLessThan(toSMT(a), toSMT(b))
+        case t if isBVType(t) => FixedSizeBitVectors.SLessThan(extendTo32(toSMT(a), a), extendTo32(toSMT(b), b))
         case IntegerType => Ints.LessThan(toSMT(a), toSMT(b))
         case RealType    => Reals.LessThan(toSMT(a), toSMT(b))
         case CharType    => FixedSizeBitVectors.SLessThan(toSMT(a), toSMT(b))
       }
       case LessEquals(a, b) => a.getType match {
-        case Int32Type   => FixedSizeBitVectors.SLessEquals(toSMT(a), toSMT(b))
+        case t if isBVType(t) => FixedSizeBitVectors.SLessEquals(extendTo32(toSMT(a), a), extendTo32(toSMT(b), b))
         case IntegerType => Ints.LessEquals(toSMT(a), toSMT(b))
         case RealType    => Reals.LessEquals(toSMT(a), toSMT(b))
         case CharType    => FixedSizeBitVectors.SLessEquals(toSMT(a), toSMT(b))
       }
       case GreaterThan(a, b) => a.getType match {
-        case Int32Type   => FixedSizeBitVectors.SGreaterThan(toSMT(a), toSMT(b))
+        case t if isBVType(t) => FixedSizeBitVectors.SGreaterThan(extendTo32(toSMT(a), a), extendTo32(toSMT(b), b))
         case IntegerType => Ints.GreaterThan(toSMT(a), toSMT(b))
         case RealType    => Reals.GreaterThan(toSMT(a), toSMT(b))
         case CharType    => FixedSizeBitVectors.SGreaterThan(toSMT(a), toSMT(b))
       }
       case GreaterEquals(a, b) => a.getType match {
-        case Int32Type   => FixedSizeBitVectors.SGreaterEquals(toSMT(a), toSMT(b))
+        case t if isBVType(t) => FixedSizeBitVectors.SGreaterEquals(extendTo32(toSMT(a), a), extendTo32(toSMT(b), b))
         case IntegerType => Ints.GreaterEquals(toSMT(a), toSMT(b))
         case RealType    => Reals.GreaterEquals(toSMT(a), toSMT(b))
         case CharType    => FixedSizeBitVectors.SGreaterEquals(toSMT(a), toSMT(b))
       }
-      case BVPlus(a, b)              => FixedSizeBitVectors.Add(toSMT(a), toSMT(b))
-      case BVMinus(a, b)             => FixedSizeBitVectors.Sub(toSMT(a), toSMT(b))
-      case BVTimes(a, b)             => FixedSizeBitVectors.Mul(toSMT(a), toSMT(b))
-      case BVDivision(a, b)          => FixedSizeBitVectors.SDiv(toSMT(a), toSMT(b))
-      case BVRemainder(a, b)         => FixedSizeBitVectors.SRem(toSMT(a), toSMT(b))
-      case BVAnd(a, b)               => FixedSizeBitVectors.And(toSMT(a), toSMT(b))
-      case BVOr(a, b)                => FixedSizeBitVectors.Or(toSMT(a), toSMT(b))
-      case BVXOr(a, b)               => FixedSizeBitVectors.XOr(toSMT(a), toSMT(b))
-      case BVShiftLeft(a, b)         => FixedSizeBitVectors.ShiftLeft(toSMT(a), toSMT(b))
-      case BVAShiftRight(a, b)       => FixedSizeBitVectors.AShiftRight(toSMT(a), toSMT(b))
-      case BVLShiftRight(a, b)       => FixedSizeBitVectors.LShiftRight(toSMT(a), toSMT(b))
+
+      case BVPlus(a, b)              => FixedSizeBitVectors.Add(extendTo32(toSMT(a), a), extendTo32(toSMT(b), b))
+      case BVMinus(a, b)             => FixedSizeBitVectors.Sub(extendTo32(toSMT(a), a), extendTo32(toSMT(b), b))
+      case BVTimes(a, b)             => FixedSizeBitVectors.Mul(extendTo32(toSMT(a), a), extendTo32(toSMT(b), b))
+      case BVDivision(a, b)          => FixedSizeBitVectors.SDiv(extendTo32(toSMT(a), a), extendTo32(toSMT(b), b))
+      case BVRemainder(a, b)         => FixedSizeBitVectors.SRem(extendTo32(toSMT(a), a), extendTo32(toSMT(b), b))
+      case BVAnd(a, b)               => FixedSizeBitVectors.And(extendTo32(toSMT(a), a), extendTo32(toSMT(b), b))
+      case BVOr(a, b)                => FixedSizeBitVectors.Or(extendTo32(toSMT(a), a), extendTo32(toSMT(b), b))
+      case BVXOr(a, b)               => FixedSizeBitVectors.XOr(extendTo32(toSMT(a), a), extendTo32(toSMT(b), b))
+      case BVShiftLeft(a, b)         => FixedSizeBitVectors.ShiftLeft(extendTo32(toSMT(a), a), extendTo32(toSMT(b), b))
+      case BVAShiftRight(a, b)       => FixedSizeBitVectors.AShiftRight(extendTo32(toSMT(a), a), extendTo32(toSMT(b), b))
+      case BVLShiftRight(a, b)       => FixedSizeBitVectors.LShiftRight(extendTo32(toSMT(a), a), extendTo32(toSMT(b), b))
 
       case RealPlus(a, b)            => Reals.Add(toSMT(a), toSMT(b))
       case RealMinus(a, b)           => Reals.Sub(toSMT(a), toSMT(b))
@@ -783,7 +787,7 @@ trait SMTLIBTarget extends Interruptible {
       case (SHexadecimal(h), Some(CharType)) =>
         CharLiteral(h.toInt.toChar)
 
-      case (SHexadecimal(hexa), Some(Int32Type)) =>
+      case (SHexadecimal(hexa), Some(t)) if isBVType(t) =>
         IntLiteral(hexa.toInt)
 
       case (SDecimal(d), Some(RealType)) =>
@@ -980,6 +984,12 @@ trait SMTLIBTarget extends Interruptible {
 
   final protected def fromSMT(s: Term, tpe: TypeTree)(implicit lets: Map[SSymbol, Term], letDefs: Map[SSymbol, DefineFun]): Expr = {
     fromSMT(s, Some(tpe))
+  }
+
+  private def extendTo32(arg: Term, orig: Expr): Term = orig.getType match {
+    case Int32Type => arg
+    case Int8Type => FixedSizeBitVectors.ZeroExtend(24, arg)
+    case t =>  context.reporter.internalError(s"Unexpected type $t for $orig")
   }
 }
 

--- a/src/main/scala/leon/solvers/smtlib/SMTLIBTarget.scala
+++ b/src/main/scala/leon/solvers/smtlib/SMTLIBTarget.scala
@@ -237,6 +237,7 @@ trait SMTLIBTarget extends Interruptible {
         case BooleanType => Core.BoolSort()
         case IntegerType => Ints.IntSort()
         case RealType    => Reals.RealSort()
+        case Int8Type    => FixedSizeBitVectors.BitVectorSort(8)
         case Int32Type   => FixedSizeBitVectors.BitVectorSort(32)
         case CharType    => FixedSizeBitVectors.BitVectorSort(32)
 
@@ -624,7 +625,7 @@ trait SMTLIBTarget extends Interruptible {
             rSubstBody
           )
         )
-      
+
 
       case BoundedForall(from, to, pred) =>
         val intType = from.getType

--- a/src/main/scala/leon/solvers/smtlib/SMTLIBTarget.scala
+++ b/src/main/scala/leon/solvers/smtlib/SMTLIBTarget.scala
@@ -780,6 +780,9 @@ trait SMTLIBTarget extends Interruptible {
       case (FixedSizeBitVectors.BitVectorConstant(n, b), Some(CharType)) if b == BigInt(32) =>
         CharLiteral(n.toInt.toChar)
 
+      case (FixedSizeBitVectors.BitVectorConstant(n, b), Some(Int8Type)) if b == BigInt(8) =>
+        ByteLiteral(b.toByte)
+
       case (FixedSizeBitVectors.BitVectorConstant(n, b), Some(Int32Type)) if b == BigInt(32) =>
         IntLiteral(n.toInt)
 
@@ -787,7 +790,7 @@ trait SMTLIBTarget extends Interruptible {
         CharLiteral(h.toInt.toChar)
 
       case (SHexadecimal(hexa), Some(Int8Type)) =>
-        IntLiteral(hexa.toInt.toByte.toInt) // Ensure the integer falls in the right range.
+        ByteLiteral(hexa.toInt.toByte)
 
       case (SHexadecimal(hexa), Some(Int32Type)) =>
         IntLiteral(hexa.toInt)

--- a/src/main/scala/leon/solvers/smtlib/SMTLIBTarget.scala
+++ b/src/main/scala/leon/solvers/smtlib/SMTLIBTarget.scala
@@ -787,7 +787,10 @@ trait SMTLIBTarget extends Interruptible {
       case (SHexadecimal(h), Some(CharType)) =>
         CharLiteral(h.toInt.toChar)
 
-      case (SHexadecimal(hexa), Some(t)) if isBVType(t) =>
+      case (SHexadecimal(hexa), Some(Int8Type)) =>
+        IntLiteral(hexa.toInt.toByte.toInt) // Ensure the integer falls in the right range.
+
+      case (SHexadecimal(hexa), Some(Int32Type)) =>
         IntLiteral(hexa.toInt)
 
       case (SDecimal(d), Some(RealType)) =>

--- a/src/main/scala/leon/solvers/smtlib/SMTLIBTarget.scala
+++ b/src/main/scala/leon/solvers/smtlib/SMTLIBTarget.scala
@@ -369,6 +369,7 @@ trait SMTLIBTarget extends Interruptible {
         declareVariable(FreshIdentifier("Unit", UnitType))
 
       case InfiniteIntegerLiteral(i) => if (i >= 0) Ints.NumeralLit(i) else Ints.Neg(Ints.NumeralLit(-i))
+      case ByteLiteral(b)            => FixedSizeBitVectors.BitVectorLit(Hexadecimal.fromString(toByteHex(b)).get)
       case IntLiteral(i)             => FixedSizeBitVectors.BitVectorLit(Hexadecimal.fromInt(i))
       case FractionalLiteral(n, d)   => Reals.Div(Reals.NumeralLit(n), Reals.NumeralLit(d))
       case CharLiteral(c)            => FixedSizeBitVectors.BitVectorLit(Hexadecimal.fromInt(c.toInt))

--- a/src/main/scala/leon/solvers/smtlib/SMTLIBTarget.scala
+++ b/src/main/scala/leon/solvers/smtlib/SMTLIBTarget.scala
@@ -509,14 +509,11 @@ trait SMTLIBTarget extends Interruptible {
 
       case Not(u)          => Core.Not(toSMT(u))
       case UMinus(u)       => Ints.Neg(toSMT(u))
-      case BVUMinus(u)     => FixedSizeBitVectors.Neg(extendTo32(toSMT(u), u))
-      case BVNot(u)        => FixedSizeBitVectors.Not(extendTo32(toSMT(u), u))
+      case BVUMinus(u)     => FixedSizeBitVectors.Neg(toSMT(u))
+      case BVNot(u)        => FixedSizeBitVectors.Not(toSMT(u))
       case Assert(a, _, b) => toSMT(IfExpr(a, b, Error(b.getType, "assertion failed")))
 
-      case Equals(a, b)    =>
-        if (isBVType(a.getType)) Core.Equals(extendTo32(toSMT(a), a), extendTo32(toSMT(b), b))
-        else Core.Equals(toSMT(a), toSMT(b))
-
+      case Equals(a, b)    => Core.Equals(toSMT(a), toSMT(b))
       case Implies(a, b)   => Core.Implies(toSMT(a), toSMT(b))
       case Plus(a, b)      => Ints.Add(toSMT(a), toSMT(b))
       case Minus(a, b)     => Ints.Sub(toSMT(a), toSMT(b))
@@ -538,41 +535,40 @@ trait SMTLIBTarget extends Interruptible {
         Ints.Mod(toSMT(a), toSMT(b))
       }
       case LessThan(a, b) => a.getType match {
-        case t if isBVType(t) => FixedSizeBitVectors.SLessThan(extendTo32(toSMT(a), a), extendTo32(toSMT(b), b))
+        case Int32Type   => FixedSizeBitVectors.SLessThan(toSMT(a), toSMT(b))
         case IntegerType => Ints.LessThan(toSMT(a), toSMT(b))
         case RealType    => Reals.LessThan(toSMT(a), toSMT(b))
         case CharType    => FixedSizeBitVectors.SLessThan(toSMT(a), toSMT(b))
       }
       case LessEquals(a, b) => a.getType match {
-        case t if isBVType(t) => FixedSizeBitVectors.SLessEquals(extendTo32(toSMT(a), a), extendTo32(toSMT(b), b))
+        case Int32Type   => FixedSizeBitVectors.SLessEquals(toSMT(a), toSMT(b))
         case IntegerType => Ints.LessEquals(toSMT(a), toSMT(b))
         case RealType    => Reals.LessEquals(toSMT(a), toSMT(b))
         case CharType    => FixedSizeBitVectors.SLessEquals(toSMT(a), toSMT(b))
       }
       case GreaterThan(a, b) => a.getType match {
-        case t if isBVType(t) => FixedSizeBitVectors.SGreaterThan(extendTo32(toSMT(a), a), extendTo32(toSMT(b), b))
+        case Int32Type   => FixedSizeBitVectors.SGreaterThan(toSMT(a), toSMT(b))
         case IntegerType => Ints.GreaterThan(toSMT(a), toSMT(b))
         case RealType    => Reals.GreaterThan(toSMT(a), toSMT(b))
         case CharType    => FixedSizeBitVectors.SGreaterThan(toSMT(a), toSMT(b))
       }
       case GreaterEquals(a, b) => a.getType match {
-        case t if isBVType(t) => FixedSizeBitVectors.SGreaterEquals(extendTo32(toSMT(a), a), extendTo32(toSMT(b), b))
+        case Int32Type   => FixedSizeBitVectors.SGreaterEquals(toSMT(a), toSMT(b))
         case IntegerType => Ints.GreaterEquals(toSMT(a), toSMT(b))
         case RealType    => Reals.GreaterEquals(toSMT(a), toSMT(b))
         case CharType    => FixedSizeBitVectors.SGreaterEquals(toSMT(a), toSMT(b))
       }
-
-      case BVPlus(a, b)              => FixedSizeBitVectors.Add(extendTo32(toSMT(a), a), extendTo32(toSMT(b), b))
-      case BVMinus(a, b)             => FixedSizeBitVectors.Sub(extendTo32(toSMT(a), a), extendTo32(toSMT(b), b))
-      case BVTimes(a, b)             => FixedSizeBitVectors.Mul(extendTo32(toSMT(a), a), extendTo32(toSMT(b), b))
-      case BVDivision(a, b)          => FixedSizeBitVectors.SDiv(extendTo32(toSMT(a), a), extendTo32(toSMT(b), b))
-      case BVRemainder(a, b)         => FixedSizeBitVectors.SRem(extendTo32(toSMT(a), a), extendTo32(toSMT(b), b))
-      case BVAnd(a, b)               => FixedSizeBitVectors.And(extendTo32(toSMT(a), a), extendTo32(toSMT(b), b))
-      case BVOr(a, b)                => FixedSizeBitVectors.Or(extendTo32(toSMT(a), a), extendTo32(toSMT(b), b))
-      case BVXOr(a, b)               => FixedSizeBitVectors.XOr(extendTo32(toSMT(a), a), extendTo32(toSMT(b), b))
-      case BVShiftLeft(a, b)         => FixedSizeBitVectors.ShiftLeft(extendTo32(toSMT(a), a), extendTo32(toSMT(b), b))
-      case BVAShiftRight(a, b)       => FixedSizeBitVectors.AShiftRight(extendTo32(toSMT(a), a), extendTo32(toSMT(b), b))
-      case BVLShiftRight(a, b)       => FixedSizeBitVectors.LShiftRight(extendTo32(toSMT(a), a), extendTo32(toSMT(b), b))
+      case BVPlus(a, b)              => FixedSizeBitVectors.Add(toSMT(a), toSMT(b))
+      case BVMinus(a, b)             => FixedSizeBitVectors.Sub(toSMT(a), toSMT(b))
+      case BVTimes(a, b)             => FixedSizeBitVectors.Mul(toSMT(a), toSMT(b))
+      case BVDivision(a, b)          => FixedSizeBitVectors.SDiv(toSMT(a), toSMT(b))
+      case BVRemainder(a, b)         => FixedSizeBitVectors.SRem(toSMT(a), toSMT(b))
+      case BVAnd(a, b)               => FixedSizeBitVectors.And(toSMT(a), toSMT(b))
+      case BVOr(a, b)                => FixedSizeBitVectors.Or(toSMT(a), toSMT(b))
+      case BVXOr(a, b)               => FixedSizeBitVectors.XOr(toSMT(a), toSMT(b))
+      case BVShiftLeft(a, b)         => FixedSizeBitVectors.ShiftLeft(toSMT(a), toSMT(b))
+      case BVAShiftRight(a, b)       => FixedSizeBitVectors.AShiftRight(toSMT(a), toSMT(b))
+      case BVLShiftRight(a, b)       => FixedSizeBitVectors.LShiftRight(toSMT(a), toSMT(b))
 
       case RealPlus(a, b)            => Reals.Add(toSMT(a), toSMT(b))
       case RealMinus(a, b)           => Reals.Sub(toSMT(a), toSMT(b))
@@ -987,12 +983,6 @@ trait SMTLIBTarget extends Interruptible {
 
   final protected def fromSMT(s: Term, tpe: TypeTree)(implicit lets: Map[SSymbol, Term], letDefs: Map[SSymbol, DefineFun]): Expr = {
     fromSMT(s, Some(tpe))
-  }
-
-  private def extendTo32(arg: Term, orig: Expr): Term = orig.getType match {
-    case Int32Type => arg
-    case Int8Type => FixedSizeBitVectors.ZeroExtend(24, arg)
-    case t =>  context.reporter.internalError(s"Unexpected type $t for $orig")
   }
 }
 

--- a/src/main/scala/leon/solvers/smtlib/SMTLIBTarget.scala
+++ b/src/main/scala/leon/solvers/smtlib/SMTLIBTarget.scala
@@ -569,6 +569,8 @@ trait SMTLIBTarget extends Interruptible {
       case BVShiftLeft(a, b)         => FixedSizeBitVectors.ShiftLeft(toSMT(a), toSMT(b))
       case BVAShiftRight(a, b)       => FixedSizeBitVectors.AShiftRight(toSMT(a), toSMT(b))
       case BVLShiftRight(a, b)       => FixedSizeBitVectors.LShiftRight(toSMT(a), toSMT(b))
+      case c @ BVWideningCast(e, _)  => FixedSizeBitVectors.SignExtend(c.to - c.from, toSMT(e))
+      case c @ BVNarrowingCast(e, _) => FixedSizeBitVectors.Extract(c.to - 1, 0, toSMT(e))
 
       case RealPlus(a, b)            => Reals.Add(toSMT(a), toSMT(b))
       case RealMinus(a, b)           => Reals.Sub(toSMT(a), toSMT(b))

--- a/src/main/scala/leon/utils/package.scala
+++ b/src/main/scala/leon/utils/package.scala
@@ -7,7 +7,7 @@ package object utils {
 
   /** compute the fixpoint of a function.
     *
-    * Apply the input function on an expression as long as until 
+    * Apply the input function on an expression as long as until
     * it stays the same (value equality) or until a set limit.
     *
     * @param f the function for which we search a fixpoint
@@ -26,5 +26,17 @@ package object utils {
     }
     v2
   }
-  
+
+  /** generate a two-digit (0-f) hex string for the given byte. */
+  def toByteHex(b: Byte): String = {
+    val h = Integer.toHexString(b)
+    if (b >= 0) {
+      val missing = 2 - h.length
+      ("0" * missing) + h
+    } else {
+      val extra = h.length - 2
+      h.drop(extra)
+    }
+  }
+
 }

--- a/src/test/resources/regression/verification/purescala/invalid/Bytes.scala
+++ b/src/test/resources/regression/verification/purescala/invalid/Bytes.scala
@@ -1,0 +1,19 @@
+/* Copyright 2009-2016 EPFL, Lausanne */
+
+import leon.lang._
+
+object Bytes {
+
+  def test(b: Byte) = {
+    require(b % 2 != 0)
+    if (b > 0) 0 else 1
+  }
+
+  def fun(b: Byte) = test(b)
+
+  def gun(b: Byte, c: Byte) = {
+    b + c
+  } ensuring { res => -128 <= res && res <= 127 }
+
+}
+

--- a/src/test/resources/regression/verification/purescala/valid/Bytes.scala
+++ b/src/test/resources/regression/verification/purescala/valid/Bytes.scala
@@ -1,0 +1,33 @@
+/* Copyright 2009-2016 EPFL, Lausanne */
+
+import leon.lang._
+
+object Bytes {
+  def fun() = {
+    val b: Byte = 127
+    test(b) == 0
+  }.holds
+
+  def test(b: Byte) = {
+    require(b % 2 != 0)
+    if (b > 0) 0 else 1
+  }
+
+  def bar(x: Int) = {
+    require(x < 128)
+    x
+  }
+
+  def gun(b: Byte): Int = {
+    assert(b >= -128 && b <= 127) // this is not a require!
+    bar(b)
+  }
+
+  def hun(i: Int) = bar(i.toByte)
+
+  def iun(b: Byte, c: Byte) = {
+    b + c
+  } ensuring { res => -256 <= res && res <= 254 }
+
+}
+

--- a/src/test/scala/leon/integration/purescala/ExplicitNumericPromotionSuite.scala
+++ b/src/test/scala/leon/integration/purescala/ExplicitNumericPromotionSuite.scala
@@ -1,0 +1,157 @@
+/* Copyright 2009-2016 EPFL, Lausanne */
+
+package leon.integration.purescala
+
+import leon.test._
+import leon.purescala.Expressions._
+import leon.purescala.Types._
+
+class ExplicitNumericPromotionSuite extends LeonTestSuiteWithProgram with helpers.ExpressionsDSL {
+  val sources = List(
+    """|object Ints {
+       |
+       |  def foo(i: Int, j: Int) = i + j
+       |
+       |  def bar(i: Int, j: Int) = i & j
+       |
+       |  def gun(i: Int) = -i
+       |
+       |} """.stripMargin,
+
+    """|object IntByte {
+       |
+       |  def foo(i: Int, j: Byte) = i + j
+       |
+       |  def bar(i: Int, j: Byte) = i & j
+       |
+       |} """.stripMargin,
+
+    """|object ByteInt {
+       |
+       |  def foo(i: Byte, j: Int) = i + j
+       |
+       |  def bar(i: Byte, j: Int) = i & j
+       |
+       |} """.stripMargin,
+
+    """|object Bytes {
+       |
+       |  def foo(i: Byte, j: Byte) = i + j
+       |
+       |  def bar(i: Byte, j: Byte) = i & j
+       |
+       |  def gun(i: Byte) = -i
+       |
+       |} """.stripMargin,
+
+    """|object ExplicitCast {
+       |
+       |  def foo(i: Int) = bar(i.toByte)
+       |
+       |  def bar(b: Byte) = b
+       |
+       |} """.stripMargin,
+
+    """|object ImplicitCast {
+       |
+       |  def foo(b: Byte) = bar(b) // implicit b.toInt here
+       |
+       |  def bar(i: Int) = i
+       |
+       |} """.stripMargin
+  )
+
+
+  test("No redundant cast on arithmetic int operations") { implicit fix =>
+    funDef("Ints.foo").fullBody match {
+      case BVPlus(Variable(i), Variable(j)) if i.name == "i" && j.name == "j" => // OK
+      case b =>
+        fail(s"Resultig body should be a simple BV addition, got '$b'")
+    }
+
+    funDef("Ints.bar").fullBody match {
+      case BVAnd(Variable(i), Variable(j)) if i.name == "i" && j.name == "j" => // OK
+      case b =>
+        fail(s"Resulting body should be a simple BV and, got '$b'")
+    }
+
+    funDef("Ints.gun").fullBody match {
+      case BVUMinus(Variable(i)) if i.name == "i" => // OK
+      case b =>
+        fail(s"Resulting body should be a simple BV unary minus, got '$b'")
+    }
+  }
+
+  test("Explicit cast on binary arithmetic operations involving ints & bytes") { implicit fix =>
+    funDef("IntByte.foo").fullBody match {
+      case BVPlus(Variable(i), Variable(j)) if i.name == "i" && j.name == "j" =>
+        fail(s"No explicit cast were inserted")
+      case BVPlus(Variable(i), BVWideningCast(Variable(j), Int32Type)) if i.name == "i" && j.name == "j" => // OK
+      case b =>
+        fail(s"Resultig body should be a BV addition with explicit cast, got '$b'")
+    }
+
+    funDef("IntByte.bar").fullBody match {
+      case BVAnd(Variable(i), BVWideningCast(Variable(j), Int32Type)) if i.name == "i" && j.name == "j" => // OK
+      case b =>
+        fail(s"Resulting body should be a BV and with explicit cast, got '$b'")
+    }
+
+    // Test symmetry
+    funDef("ByteInt.foo").fullBody match {
+      case BVPlus(Variable(i), Variable(j)) if i.name == "i" && j.name == "j" =>
+        fail(s"No explicit cast were inserted")
+      case BVPlus(BVWideningCast(Variable(i), Int32Type), Variable(j)) if i.name == "i" && j.name == "j" => // OK
+      case b =>
+        fail(s"Resultig body should be a BV addition with explicit cast, got '$b'")
+    }
+
+    funDef("ByteInt.bar").fullBody match {
+      case BVAnd(BVWideningCast(Variable(i), Int32Type), Variable(j)) if i.name == "i" && j.name == "j" => // OK
+      case b =>
+        fail(s"Resulting body should be a BV and with explicit cast, got '$b'")
+    }
+  }
+
+  test("Explicit cast on arithmetic operations involving only bytes") { implicit fix =>
+    funDef("Bytes.foo").fullBody match {
+      case BVPlus(BVWideningCast(Variable(i), Int32Type), BVWideningCast(Variable(j), Int32Type))
+        if i.name == "i" && j.name == "j" => // OK
+      case b =>
+        fail(s"Resultig body should be a BV addition  with widening cast, got '$b'")
+    }
+
+    funDef("Bytes.bar").fullBody match {
+      case BVAnd(BVWideningCast(Variable(i), Int32Type), BVWideningCast(Variable(j), Int32Type))
+        if i.name == "i" && j.name == "j" => // OK
+      case b =>
+        fail(s"Resulting body should be a BV and with widening cast, got '$b'")
+    }
+
+    funDef("Bytes.gun").fullBody match {
+      case BVUMinus(BVWideningCast(Variable(i), Int32Type)) if i.name == "i" => // OK
+      case b =>
+        fail(s"Resulting body should be a BV unary minus with widening cast, got '$b'")
+    }
+  }
+
+  test("Explicit casts should be preserved") { implicit fix =>
+    funDef("ExplicitCast.foo").fullBody match {
+      case FunctionInvocation(tfd, Seq(BVNarrowingCast(Variable(i), Int8Type)))
+        if tfd.id.name == "bar" && i.name == "i" => // OK
+      case b =>
+        fail(s"Resultig body should be a function call with one narrowing cast on its only argument, got '$b'")
+    }
+  }
+
+  test("Implicit casts should be preserved") { implicit fix =>
+    funDef("ImplicitCast.foo").fullBody match {
+      case FunctionInvocation(tfd, Seq(BVWideningCast(Variable(b), Int32Type)))
+        if tfd.id.name == "bar" && b.name == "b" => // OK
+      case b =>
+        fail(s"Resultig body should be a function call with one widening cast on its only argument, got '$b'")
+    }
+  }
+
+}
+

--- a/src/test/scala/leon/unit/evaluators/EvaluatorSuite.scala
+++ b/src/test/scala/leon/unit/evaluators/EvaluatorSuite.scala
@@ -55,6 +55,7 @@ class EvaluatorSuite extends LeonTestSuite with helpers.ExpressionsDSL {
       eval(e, BVPlus(IntLiteral(3), IntLiteral(5)))  === IntLiteral(8)
       eval(e, BVPlus(IntLiteral(0), IntLiteral(5)))  === IntLiteral(5)
       eval(e, BVTimes(IntLiteral(3), IntLiteral(3))) === IntLiteral(9)
+      eval(e, BVPlus(IntLiteral(1), BVWideningCast(ByteLiteral(1), Int32Type))) === IntLiteral(2)
     }
   }
 
@@ -82,6 +83,12 @@ class EvaluatorSuite extends LeonTestSuite with helpers.ExpressionsDSL {
 
       eval(e, BVLShiftRight(IntLiteral(8), IntLiteral(1))) === IntLiteral(4)
       eval(e, BVAShiftRight(IntLiteral(8), IntLiteral(1))) === IntLiteral(4)
+
+      eval(e, BVNarrowingCast(
+                BVAnd(BVWideningCast(ByteLiteral(1), Int32Type),
+                      BVWideningCast(ByteLiteral(2), Int32Type)),
+                Int8Type)
+      ) === ByteLiteral(0)
     }
   }
 
@@ -240,6 +247,9 @@ class EvaluatorSuite extends LeonTestSuite with helpers.ExpressionsDSL {
 
       eval(e, ArraySelect(finiteArray(Seq(IntLiteral(2), IntLiteral(4), IntLiteral(7))), IntLiteral(1))) ===
                       IntLiteral(4)
+
+      eval(e, ArraySelect(finiteArray(Seq(ByteLiteral(42), ByteLiteral(58))), IntLiteral(0))) ===
+                      ByteLiteral(42)
 
       eqArray(eval(e, ArrayUpdated( finiteArray(Seq(IntLiteral(2), IntLiteral(4), IntLiteral(7))), IntLiteral(1), IntLiteral(42))).res,
                       finiteArray(Seq(IntLiteral(2), IntLiteral(42), IntLiteral(7))))


### PR DESCRIPTION
Introduce Byte (8-bit integer) in Leon with support for verification (SMTs, z3) & evaluation (CodeGen, Orb, Recursive, Stream). Support for other kinds of integer (e.g. Short, Long) can be added in the same fashion.

Concretely, this adds a new type (`Int8Type`), a new literal kind (`ByteLiteral` *), and two new operations on bit-vectors (`BVNarrowingCast` & `BVWideningCast`) for explicit narrowing and (most of the time implicit) widening of integer types.

The `CodeExtraction` explicitly introduces `BVWideningCast` on any arithmetic operations to ensure the resulting AST matches the Java semantics of [5.6.1. Unary Numeric Promotion](https://docs.oracle.com/javase/specs/jls/se8/html/jls-5.html#jls-5.6.1) & [5.6.2. Binary Numeric Promotion](https://docs.oracle.com/javase/specs/jls/se8/html/jls-5.html#jls-5.6.2) over operation involving bytes and mix of bytes and integers so that "downstream" phases do not have to deal with these rules themselves.

The added unit & regression tests are all green, however, because this PR impacts areas of Leon which I'm not so familiar with, I'd welcome feedback on this before merging it into the master branch.


-----

(*) The literal types should probably be called `Int8Literal` & `Int32Literal` instead of `ByteLiteral` & `IntLiteral` but since a large portion of Leon already refers to 32-bit literal as `IntLiteral`, I recommend postpone this renaming to a later refactoring.