### PR TITLE
Topic/strict arithmetic: more verification tools

### DIFF
--- a/src/main/scala/leon/verification/DefaultTactic.scala
+++ b/src/main/scala/leon/verification/DefaultTactic.scala
@@ -84,7 +84,7 @@ class DefaultTactic(vctx: VerificationContext) extends Tactic(vctx) {
           VCKinds.Assert
         }
 
-      case BVPlus(_, _) | BVMinus(_, _) | BVTimes(_, _) =>
+      case BVPlus(_, _) | BVMinus(_, _) | BVUMinus(_) | BVTimes(_, _) =>
         VCKinds.ArithmeticOverflow
 
       case _ =>
@@ -135,6 +135,11 @@ class DefaultTactic(vctx: VerificationContext) extends Tactic(vctx) {
 
       case e @ BVTimes(x, y) if overflowChecking =>
         val cond = or(equality(x, IntLiteral(0)), equality(BVDivision(BVTimes(x,y), x), y))
+        (e, cond)
+
+      case e @ BVUMinus(x) if overflowChecking =>
+        assert(x.getType == Int32Type) // other kind of bv not covered here
+        val cond = not(equality(x, IntLiteral(Int.MinValue))) // -2^31
         (e, cond)
 
       /*case e @ Ensuring(body, post) =>

--- a/src/main/scala/leon/verification/DefaultTactic.scala
+++ b/src/main/scala/leon/verification/DefaultTactic.scala
@@ -151,6 +151,10 @@ class DefaultTactic(vctx: VerificationContext) extends Tactic(vctx) {
         val cond = or(equality(x, IntLiteral(0)), equality(BVDivision(BVTimes(x,y), x), y))
         (e, cond)
 
+      case e @ BVDivision(x, y) if overflowChecking =>
+        val cond = not(and(equality(x, IntLiteral(Int.MinValue)), equality(y, IntLiteral(-1))))
+        (e, cond)
+
       case e @ BVUMinus(x) if overflowChecking =>
         assert(x.getType == Int32Type) // other kind of bv not covered here
         val cond = not(equality(x, IntLiteral(Int.MinValue))) // -2^31

--- a/src/main/scala/leon/verification/DefaultTactic.scala
+++ b/src/main/scala/leon/verification/DefaultTactic.scala
@@ -30,7 +30,7 @@ class DefaultTactic(vctx: VerificationContext) extends Tactic(vctx) {
               ).copiedFrom(post)
           }}
           else post
-        
+
         val vc = implies(fd.precOrTrue, application(newpost, Seq(body)))
         Seq(VC(vc, fd, VCKinds.Postcondition).setPos(post))
       case _ =>
@@ -72,6 +72,8 @@ class DefaultTactic(vctx: VerificationContext) extends Tactic(vctx) {
           VCKinds.ModuloByZero
         } else if (err.startsWith("Remainder ")) {
           VCKinds.RemainderByZero
+        } else if (err.startsWith("Strict arithmetic")) {
+          VCKinds.StrictArithmetic
         } else if (err.startsWith("Bit-vector arithmetic overflow")) {
           VCKinds.ArithmeticOverflow
         } else if (err.startsWith("Cast ")) {

--- a/src/main/scala/leon/verification/DefaultTactic.scala
+++ b/src/main/scala/leon/verification/DefaultTactic.scala
@@ -85,7 +85,7 @@ class DefaultTactic(vctx: VerificationContext) extends Tactic(vctx) {
           VCKinds.Assert
         }
 
-      case BVShiftLeft(_, _) | BVAShiftRight(_, _) | BVLShiftRight(_, _) =>
+      case BVRemainder(_, _) | BVShiftLeft(_, _) | BVAShiftRight(_, _) | BVLShiftRight(_, _) =>
         VCKinds.StrictArithmetic
 
       case BVPlus(_, _) | BVMinus(_, _) | BVUMinus(_) | BVTimes(_, _) =>
@@ -152,6 +152,13 @@ class DefaultTactic(vctx: VerificationContext) extends Tactic(vctx) {
         (e, cond)
 
       case e @ BVDivision(x, y) if overflowChecking =>
+        assert(x.getType == Int32Type) // other kind of bv not covered here
+        val cond = not(and(equality(x, IntLiteral(Int.MinValue)), equality(y, IntLiteral(-1))))
+        (e, cond)
+
+      // This is not really an overflow, but rather a limitation of C so we treat it as a strict arithmetic problem
+      case e @ BVRemainder(x, y) if strictArithmeticChecking =>
+        assert(x.getType == Int32Type) // other kind of bv not covered here
         val cond = not(and(equality(x, IntLiteral(Int.MinValue)), equality(y, IntLiteral(-1))))
         (e, cond)
 

--- a/src/main/scala/leon/verification/InjectAsserts.scala
+++ b/src/main/scala/leon/verification/InjectAsserts.scala
@@ -14,15 +14,25 @@ object InjectAsserts extends SimpleLeonPhase[Program, Program] {
   val name = "Asserts"
   val description = "Inject asserts for various correctness conditions (map accesses, array accesses, divisions by zero,..)"
 
-  val optOverflowChecking = LeonFlagOptionDef("overflow", "Check arithmetic overflow", default = false)  
-  
-  override val definedOptions: Set[LeonOptionDef[Any]] = Set(optOverflowChecking)
+  val optStrictArithmeticChecking = LeonFlagOptionDef(
+    "strict-arithmetic",
+    "Check arithmetic operations for unintended behaviour (implies --overflow)",
+    default = false
+  )
+
+  val optOverflowChecking = LeonFlagOptionDef("overflow", "Check arithmetic overflow", default = false)
+
+  override val definedOptions: Set[LeonOptionDef[Any]] = Set(optStrictArithmeticChecking, optOverflowChecking)
 
   def apply(ctx: LeonContext, pgm: Program): Program = {
-    val overflowChecking: Boolean = ctx.findOptionOrDefault(optOverflowChecking)
+
+    val strictArithmeticChecking: Boolean = ctx.findOptionOrDefault(optStrictArithmeticChecking)
+    val overflowChecking: Boolean = ctx.findOptionOrDefault(optOverflowChecking) || strictArithmeticChecking
+
     def indexUpTo(i: Expr, e: Expr) = {
       and(GreaterEquals(i, IntLiteral(0)), LessThan(i, e))
     }
+
     val mask = IntLiteral(0x80000000)
     def applyMask(a: Expr): Expr = BVAnd(a, mask)
 

--- a/src/main/scala/leon/verification/InjectAsserts.scala
+++ b/src/main/scala/leon/verification/InjectAsserts.scala
@@ -14,27 +14,11 @@ object InjectAsserts extends SimpleLeonPhase[Program, Program] {
   val name = "Asserts"
   val description = "Inject asserts for various correctness conditions (map accesses, array accesses, divisions by zero,..)"
 
-  val optStrictArithmeticChecking = LeonFlagOptionDef(
-    "strict-arithmetic",
-    "Check arithmetic operations for unintended behaviour (implies --overflow)",
-    default = false
-  )
-
-  val optOverflowChecking = LeonFlagOptionDef("overflow", "Check arithmetic overflow", default = false)
-
-  override val definedOptions: Set[LeonOptionDef[Any]] = Set(optStrictArithmeticChecking, optOverflowChecking)
-
   def apply(ctx: LeonContext, pgm: Program): Program = {
-
-    val strictArithmeticChecking: Boolean = ctx.findOptionOrDefault(optStrictArithmeticChecking)
-    val overflowChecking: Boolean = ctx.findOptionOrDefault(optOverflowChecking) || strictArithmeticChecking
 
     def indexUpTo(i: Expr, e: Expr) = {
       and(GreaterEquals(i, IntLiteral(0)), LessThan(i, e))
     }
-
-    val mask = IntLiteral(0x80000000)
-    def applyMask(a: Expr): Expr = BVAnd(a, mask)
 
     pgm.definedFunctions.foreach(fd => {
       fd.body = fd.body.map(postMap {
@@ -81,29 +65,6 @@ object InjectAsserts extends SimpleLeonPhase[Program, Program] {
                       Some("Remainder by zero"),
                       e
                      ).setPos(e))
-
-        case e @ BVPlus(x, y) if overflowChecking =>
-          Some(assertion(
-            Implies(equality(applyMask(x), applyMask(y)),
-                    equality(applyMask(x), applyMask(e))),
-            Some("Bit-vector arithmetic overflow"),
-            e
-          ).setPos(e))
-        case e @ BVMinus(x, y) if overflowChecking =>
-          Some(assertion(
-            Implies(not(equality(applyMask(x), applyMask(y))),
-                    equality(applyMask(x), applyMask(e)))
-            ,
-            Some("Bit-vector arithmetic overflow"),
-            e
-          ).setPos(e))
-        case e @ BVTimes(x, y) if overflowChecking =>
-          Some(assertion(
-            or(equality(x, IntLiteral(0)),
-               equality(BVDivision(BVTimes(x,y), x), y)),
-            Some("Bit-vector arithmetic overflow"),
-            e
-          ).setPos(e))
 
         case e @ RealDivision(_, d)  =>
           Some(assertion(not(equality(d, FractionalLiteral(0, 1))),

--- a/src/main/scala/leon/verification/VerificationCondition.scala
+++ b/src/main/scala/leon/verification/VerificationCondition.scala
@@ -50,7 +50,8 @@ object VCKinds {
   case object ModuloByZero    extends VCKind("modulo by zero", "mod 0")
   case object RemainderByZero extends VCKind("remainder by zero", "rem 0")
   case object CastError       extends VCKind("cast correctness", "cast")
-  case object PostTactVC          extends VCKind("Postcondition Tactic", "tact")
+  case object PostTactVC         extends VCKind("Postcondition Tactic", "tact")
+  case object StrictArithmetic   extends VCKind("strict arithmetic", "arithmetic")
   case object ArithmeticOverflow extends VCKind("arithmetic overflow", "overflow")
 }
 

--- a/src/test/resources/regression/verification/overflow/invalid/Overflow1.scala
+++ b/src/test/resources/regression/verification/overflow/invalid/Overflow1.scala
@@ -52,4 +52,9 @@ object Overflow1 {
     -x
   }
 
+  def foo13(x: Int, y: Int) = {
+    require(y != 0)
+    x / y
+  }
+
 }

--- a/src/test/resources/regression/verification/overflow/invalid/Overflow1.scala
+++ b/src/test/resources/regression/verification/overflow/invalid/Overflow1.scala
@@ -47,4 +47,9 @@ object Overflow1 {
     val y = 500000
     x*y
   }
+
+  def foo12(x: Int): Int = {
+    -x
+  }
+
 }

--- a/src/test/resources/regression/verification/overflow/invalid/Overflow1.scala
+++ b/src/test/resources/regression/verification/overflow/invalid/Overflow1.scala
@@ -2,59 +2,8 @@ import leon.lang._
 
 object Overflow1 {
 
-  def foo(x: Int): Int = {
+  def foo1(x: Int): Int = {
     x + 1
-  }
-
-  def foo2(x: Int): Int = {
-    x + (-1)
-  }
-
-  def foo3(x: Int): Int = {
-    x - 1
-  }
-
-  def foo4(x: Int): Int = {
-    x - (-1)
-  }
-
-  def foo5(x: Int, y: Int): Int = {
-    x + y
-  }
-
-  def foo6(x: Int, y: Int): Int = {
-    x - y
-  }
-
-  def foo7(x: Int): Int = {
-    x*2
-  }
-
-  def foo8(x: Int): Int = {
-    x*3
-  }
-
-  def foo9(x: Int): Int = {
-    x*4
-  }
-
-  def foo10(x: Int, y: Int): Int = {
-    x*y
-  }
-
-  def foo11(): Int = {
-    val x = 500000
-    val y = 500000
-    x*y
-  }
-
-  def foo12(x: Int): Int = {
-    -x
-  }
-
-  def foo13(x: Int, y: Int) = {
-    require(y != 0)
-    x / y
   }
 
 }

--- a/src/test/resources/regression/verification/overflow/invalid/Overflow10.scala
+++ b/src/test/resources/regression/verification/overflow/invalid/Overflow10.scala
@@ -1,0 +1,9 @@
+import leon.lang._
+
+object Overflow10 {
+
+  def foo10(x: Int, y: Int): Int = {
+    x*y
+  }
+
+}

--- a/src/test/resources/regression/verification/overflow/invalid/Overflow11.scala
+++ b/src/test/resources/regression/verification/overflow/invalid/Overflow11.scala
@@ -1,0 +1,11 @@
+import leon.lang._
+
+object Overflow11 {
+
+  def foo11(): Int = {
+    val x = 500000
+    val y = 500000
+    x*y
+  }
+
+}

--- a/src/test/resources/regression/verification/overflow/invalid/Overflow12.scala
+++ b/src/test/resources/regression/verification/overflow/invalid/Overflow12.scala
@@ -1,0 +1,9 @@
+import leon.lang._
+
+object Overflow12 {
+
+  def foo12(x: Int): Int = {
+    -x
+  }
+
+}

--- a/src/test/resources/regression/verification/overflow/invalid/Overflow13.scala
+++ b/src/test/resources/regression/verification/overflow/invalid/Overflow13.scala
@@ -1,0 +1,10 @@
+import leon.lang._
+
+object Overflow13 {
+
+  def foo13(x: Int, y: Int) = {
+    require(y != 0)
+    x / y
+  }
+
+}

--- a/src/test/resources/regression/verification/overflow/invalid/Overflow2.scala
+++ b/src/test/resources/regression/verification/overflow/invalid/Overflow2.scala
@@ -1,0 +1,9 @@
+import leon.lang._
+
+object Overflow2 {
+
+  def foo2(x: Int): Int = {
+    x + (-1)
+  }
+
+}

--- a/src/test/resources/regression/verification/overflow/invalid/Overflow3.scala
+++ b/src/test/resources/regression/verification/overflow/invalid/Overflow3.scala
@@ -1,0 +1,9 @@
+import leon.lang._
+
+object Overflow3 {
+
+  def foo3(x: Int): Int = {
+    x - 1
+  }
+
+}

--- a/src/test/resources/regression/verification/overflow/invalid/Overflow4.scala
+++ b/src/test/resources/regression/verification/overflow/invalid/Overflow4.scala
@@ -1,0 +1,9 @@
+import leon.lang._
+
+object Overflow4 {
+
+  def foo4(x: Int): Int = {
+    x - (-1)
+  }
+
+}

--- a/src/test/resources/regression/verification/overflow/invalid/Overflow5.scala
+++ b/src/test/resources/regression/verification/overflow/invalid/Overflow5.scala
@@ -1,0 +1,9 @@
+import leon.lang._
+
+object Overflow5 {
+
+  def foo5(x: Int, y: Int): Int = {
+    x + y
+  }
+
+}

--- a/src/test/resources/regression/verification/overflow/invalid/Overflow6.scala
+++ b/src/test/resources/regression/verification/overflow/invalid/Overflow6.scala
@@ -1,0 +1,9 @@
+import leon.lang._
+
+object Overflow6 {
+
+  def foo6(x: Int, y: Int): Int = {
+    x - y
+  }
+
+}

--- a/src/test/resources/regression/verification/overflow/invalid/Overflow7.scala
+++ b/src/test/resources/regression/verification/overflow/invalid/Overflow7.scala
@@ -1,0 +1,9 @@
+import leon.lang._
+
+object Overflow7 {
+
+  def foo7(x: Int): Int = {
+    x*2
+  }
+
+}

--- a/src/test/resources/regression/verification/overflow/invalid/Overflow8.scala
+++ b/src/test/resources/regression/verification/overflow/invalid/Overflow8.scala
@@ -1,0 +1,9 @@
+import leon.lang._
+
+object Overflow8 {
+
+  def foo8(x: Int): Int = {
+    x*3
+  }
+
+}

--- a/src/test/resources/regression/verification/overflow/invalid/Overflow9.scala
+++ b/src/test/resources/regression/verification/overflow/invalid/Overflow9.scala
@@ -1,0 +1,9 @@
+import leon.lang._
+
+object Overflow9 {
+
+  def foo9(x: Int): Int = {
+    x*4
+  }
+
+}

--- a/src/test/resources/regression/verification/overflow/valid/Overflow1.scala
+++ b/src/test/resources/regression/verification/overflow/valid/Overflow1.scala
@@ -58,4 +58,9 @@ object Overflow1 {
     -x
   }
 
+  def foo13(x: Int, y: Int) = {
+    require(y != 0 && (x != -2147483648 || y != -1))
+    x / y
+  }
+
 }

--- a/src/test/resources/regression/verification/overflow/valid/Overflow1.scala
+++ b/src/test/resources/regression/verification/overflow/valid/Overflow1.scala
@@ -52,4 +52,10 @@ object Overflow1 {
   //  val y = 500000
   //  x*y
   //}
+
+  def foo12(x: Int): Int = {
+    require(x != -2147483648) // -2^31
+    -x
+  }
+
 }

--- a/src/test/resources/regression/verification/strictarithmetic/invalid/StrictArithmetic1.scala
+++ b/src/test/resources/regression/verification/strictarithmetic/invalid/StrictArithmetic1.scala
@@ -1,0 +1,18 @@
+import leon.lang._
+
+object StrictArithmetic1 {
+
+  def foo(x: Int, y: Int) = {
+    x << y
+  }
+
+  def foo2(x: Int, y: Int) = {
+    x >> y
+  }
+
+  def foo3(x: Int, y: Int) = {
+    x >>> y
+  }
+
+}
+

--- a/src/test/resources/regression/verification/strictarithmetic/invalid/StrictArithmetic1.scala
+++ b/src/test/resources/regression/verification/strictarithmetic/invalid/StrictArithmetic1.scala
@@ -2,20 +2,8 @@ import leon.lang._
 
 object StrictArithmetic1 {
 
-  def foo(x: Int, y: Int) = {
+  def foo1(x: Int, y: Int) = {
     x << y
-  }
-
-  def foo2(x: Int, y: Int) = {
-    x >> y
-  }
-
-  def foo3(x: Int, y: Int) = {
-    x >>> y
-  }
-
-  def foo4(x: Int, y: Int) = {
-    x % y
   }
 
 }

--- a/src/test/resources/regression/verification/strictarithmetic/invalid/StrictArithmetic1.scala
+++ b/src/test/resources/regression/verification/strictarithmetic/invalid/StrictArithmetic1.scala
@@ -14,5 +14,9 @@ object StrictArithmetic1 {
     x >>> y
   }
 
+  def foo4(x: Int, y: Int) = {
+    x % y
+  }
+
 }
 

--- a/src/test/resources/regression/verification/strictarithmetic/invalid/StrictArithmetic2.scala
+++ b/src/test/resources/regression/verification/strictarithmetic/invalid/StrictArithmetic2.scala
@@ -1,0 +1,10 @@
+import leon.lang._
+
+object StrictArithmetic2 {
+
+  def foo2(x: Int, y: Int) = {
+    x >> y
+  }
+
+}
+

--- a/src/test/resources/regression/verification/strictarithmetic/invalid/StrictArithmetic3.scala
+++ b/src/test/resources/regression/verification/strictarithmetic/invalid/StrictArithmetic3.scala
@@ -1,0 +1,10 @@
+import leon.lang._
+
+object StrictArithmetic3 {
+
+  def foo3(x: Int, y: Int) = {
+    x >>> y
+  }
+
+}
+

--- a/src/test/resources/regression/verification/strictarithmetic/invalid/StrictArithmetic4.scala
+++ b/src/test/resources/regression/verification/strictarithmetic/invalid/StrictArithmetic4.scala
@@ -1,0 +1,10 @@
+import leon.lang._
+
+object StrictArithmetic4 {
+
+  def foo4(x: Int, y: Int) = {
+    x % y
+  }
+
+}
+

--- a/src/test/resources/regression/verification/strictarithmetic/valid/StrictArithmetic1.scala
+++ b/src/test/resources/regression/verification/strictarithmetic/valid/StrictArithmetic1.scala
@@ -17,5 +17,10 @@ object StrictArithmetic1 {
     x >>> y
   }
 
+  def foo4(x: Int, y: Int) = {
+    require(y != 0 && (x != -2147483648 || y != -1))
+    x % y
+  }
+
 }
 

--- a/src/test/resources/regression/verification/strictarithmetic/valid/StrictArithmetic1.scala
+++ b/src/test/resources/regression/verification/strictarithmetic/valid/StrictArithmetic1.scala
@@ -1,0 +1,21 @@
+import leon.lang._
+
+object StrictArithmetic1 {
+
+  def foo(x: Int, y: Int) = {
+    require(0 <= y && y <= 31)
+    x << y
+  }
+
+  def foo2(x: Int, y: Int) = {
+    require(0 <= y && y <= 31)
+    x >> y
+  }
+
+  def foo3(x: Int, y: Int) = {
+    require(0 <= y && y <= 31)
+    x >>> y
+  }
+
+}
+

--- a/src/test/scala/leon/regression/verification/StrictArithmeticSuite.scala
+++ b/src/test/scala/leon/regression/verification/StrictArithmeticSuite.scala
@@ -1,0 +1,24 @@
+/* Copyright 2009-2016 EPFL, Lausanne */
+
+package leon.regression.verification
+
+import leon.solvers.SolverFactory
+
+class StrictArithmeticSuite extends VerificationSuite {
+
+  val optionVariants: List[List[String]] = {
+    val isZ3Available = SolverFactory.hasZ3
+
+    (List(
+      List(),
+      List("--feelinglucky")
+    ) ++ (
+      if (isZ3Available)
+        List(List("--solvers=smt-z3", "--feelinglucky"))
+      else Nil
+    )).map ("--timeout=300" :: "--strict-arithmetic" :: _)
+  }
+
+  val testDir: String = "regression/verification/strictarithmetic/"
+}
+


### PR DESCRIPTION
This updates `--overflow` and adds `--strict-arithmetic`.

Overflow verification now includes unary minus (`-MIN_INT === MIN_INT` but this is still an overflow) and division (`MIN_INT / -1 === MIN_INT` also wraps around).

The strict arithmetic option intends to reveal unexpected behaviour or potential bugs in the user code. For example, shift operators in Java are defined to use, when the promoted type of left hand side operand is `int`, only the 5 lowest-order bits of the right hand side operand. Therefore, `--strict-arithmetic` checks that the *lhs* operand is in the range [0,31].

Additionally, because `--strict-arithmetic` is intended to be used jointly with GenC, undefined behaviour specific to C99 is also checked, such as that `MIN_INT % -1` doesn't occur in the program.

A proper documentation will be written later in a separate PR.