### PR TITLE
Fix MethodLifting by properly updating identifiers in nested functions

### DIFF
--- a/src/main/scala/leon/purescala/TreeTransformer.scala
+++ b/src/main/scala/leon/purescala/TreeTransformer.scala
@@ -39,7 +39,11 @@ trait TreeTransformer {
       val newA = transform(a)
       LetVar(newA, transform(expr), transform(body)(bindings + (a -> newA))).copiedFrom(e)
     case LetDef(fds, body) =>
-      val rFds = fds map transform
+      val rFds = fds map { f =>
+        val g = transform(f)
+        g.fullBody = transform(g.fullBody) // use bindings
+        g
+      }
       val rBody = transform(body)
       LetDef(rFds, rBody).copiedFrom(e)
     case CaseClass(cct, args) =>


### PR DESCRIPTION
Actually, the underlying bug is in TreeTransformer: the mapping from old to new identifier is not propagated into nested functions.

---

#### Details

Commits like https://github.com/epfl-lara/leon/commit/da777de759f2d2a040f2cec9744efb18456e5493 break [many tests](http://laraquad4.epfl.ch:9000/epfl-lara/leon/build/1338) because the identifier of nested functions are not kept in sync with the lifted methods.

This PR fixes this issue in a general manner: any tree transformer is now updated to handle this.