### PR TITLE
Make pretty printer more robust on weirdly shaped trees

### DIFF
--- a/src/main/scala/leon/evaluators/RecursiveEvaluator.scala
+++ b/src/main/scala/leon/evaluators/RecursiveEvaluator.scala
@@ -786,7 +786,10 @@ abstract class RecursiveEvaluator(ctx: LeonContext, prog: Program, val bank: Eva
       }
 
     case f @ FiniteArray(elems, default, length) =>
-      val ArrayType(tp) = f.getType
+      val tp = f.getType match {
+        case ArrayType(tp) => tp
+        case typ => throw RuntimeError(s"Unexpected expression of non-array type: $f")
+      }
       finiteArray(
         elems.map(el => (el._1, e(el._2))),
         default.map{ d => (e(d), e(length)) },

--- a/src/main/scala/leon/purescala/PrettyPrinter.scala
+++ b/src/main/scala/leon/purescala/PrettyPrinter.scala
@@ -381,10 +381,13 @@ class PrettyPrinter(opts: PrinterOptions,
       case ArraySelect(a, i)        => p"$a($i)"
       case ArrayUpdated(a, i, v)    => p"$a.updated($i, $v)"
       case a @ FiniteArray(es, d, s) => {
-        val ArrayType(underlying) = a.getType
-        val default = d.getOrElse(simplestValue(underlying))
         def ppBigArray(): Unit = {
           if (es.isEmpty) {
+            val simplest = a.getType match {
+              case ArrayType(underlying) => simplestValue(underlying)
+              case _ => NoTree
+            }
+            val default = d.getOrElse(simplest)
             p"Array($default, $default, $default, ..., $default) (of size $s)"
           } else {
             p"Array(_) (of size $s)"

--- a/src/main/scala/leon/purescala/ScalaPrinter.scala
+++ b/src/main/scala/leon/purescala/ScalaPrinter.scala
@@ -47,8 +47,10 @@ class ScalaPrinter(opts: PrinterOptions,
       case InfiniteIntegerLiteral(v) => p"BigInt($v)"
       case a@FiniteArray(elems, oDef, size) =>
         import ExprOps._
-        val ArrayType(underlying) = a.getType
-        val default = oDef.getOrElse(simplestValue(underlying))
+        val default = a.getType match {
+          case ArrayType(underlying) => oDef getOrElse simplestValue(underlying)
+          case _ => NoTree
+        }
         size match {
           case IntLiteral(s) => {
             val explicitArray = Array.fill(s)(default)


### PR DESCRIPTION
This is a quick hack prevent the pattern matching to fail.