### PR TITLE
Catch SolverUnsupportedError and report VC as unsupported

### DIFF
--- a/src/main/scala/leon/verification/VerificationCondition.scala
+++ b/src/main/scala/leon/verification/VerificationCondition.scala
@@ -109,4 +109,5 @@ object VCStatus {
   case object Timeout extends VCStatus("timeout")
   case object Cancelled extends VCStatus("cancelled")
   case object Crashed extends VCStatus("crashed")
+  case object Unsupported extends VCStatus("unsupported")
 }


### PR DESCRIPTION
Instead of crashing and losing all the verification reports build until now.