### PR TITLE
Make pattern matching on Untyped arrays slightly more robust

### DIFF
--- a/src/main/scala/leon/purescala/Extractors.scala
+++ b/src/main/scala/leon/purescala/Extractors.scala
@@ -244,7 +244,11 @@ object Extractors {
         }))
       case na @ EmptyArray(t) => Some(Seq[Expr](), (_:Seq[Expr]) => na)
       case na @ NonemptyArray(elems, None) =>
-        val ArrayType(tpe) = na.getType
+        val tpe = na.getType match {
+          case ArrayType(tpe) => tpe
+          case Untyped => Untyped
+          case tpe => sys.error(s"Unexpected type $tpe")
+        }
         val (indexes, elsOrdered) = elems.toSeq.unzip
 
         Some((


### PR DESCRIPTION
This improves on #283.

With this fix, Leon won't crash anymore on my LZW implementations when running verification. :-)