### PR TITLE
GenC: various updates

### DIFF
--- a/src/main/scala/leon/frontends/scalac/ASTExtractors.scala
+++ b/src/main/scala/leon/frontends/scalac/ASTExtractors.scala
@@ -1084,16 +1084,6 @@ trait ASTExtractors {
       }
     }
 
-    object ExSomeConstruction {
-      def unapply(tree: Apply) : Option[(Type,Tree)] = tree match {
-        case Apply(s @ Select(New(tpt), n), arg) if arg.size == 1 && n == nme.CONSTRUCTOR && tpt.symbol.name.toString == "Some" => tpt.tpe match {
-          case TypeRef(_, sym, tpe :: Nil) => Some((tpe, arg.head))
-          case _ => None
-        }
-        case _ => None
-      }
-    }
-
     object ExCaseClassConstruction {
       def unapply(tree: Apply): Option[(Tree,Seq[Tree])] = tree match {
         case Apply(s @ Select(New(tpt), n), args) if n == nme.CONSTRUCTOR => {

--- a/src/main/scala/leon/frontends/scalac/ASTExtractors.scala
+++ b/src/main/scala/leon/frontends/scalac/ASTExtractors.scala
@@ -1100,8 +1100,15 @@ trait ASTExtractors {
           Some((tpt, args))
         }
         //essentially this ignores implicit evidence for mutable types annotations
-        case Apply(Apply(s @ Select(New(tpt), n), args), List(TypeApply(ExSelected("leon", "lang", "package", "mutable"), tps))) if n == nme.CONSTRUCTOR => {
-          //println("stuff tps: " + tps)
+        case Apply(Apply(Select(New(tpt), n), args),
+                   List(TypeApply(ExSelected("leon", "lang", "package", "mutable"), _)))
+             if n == nme.CONSTRUCTOR => {
+          Some((tpt, args))
+        }
+        case Apply(Apply(Select(New(tpt), n), args),
+                   List(s @ Select(qualifier, symbol)))
+             if n == nme.CONSTRUCTOR && s.tpe.typeSymbol.fullName == "leon.lang.Mutable" => {
+          // s.tpe === TypeRef( SingleType( SingleType( SingleType( ThisType(<root>),  leon),  lang),  package),  Mutable,  [ TypeRef( NoPrefix(),  V,  [ ])])
           Some((tpt, args))
         }
         case _ => None

--- a/src/main/scala/leon/frontends/scalac/CodeExtraction.scala
+++ b/src/main/scala/leon/frontends/scalac/CodeExtraction.scala
@@ -215,7 +215,11 @@ trait CodeExtraction extends ASTExtractors {
         case ctor @ExConstructorDef() => ctor
       }.get.asInstanceOf[DefDef]
 
-      val valDefs = constructor.vparamss.flatten
+      // Ignore synthetic evidence for mutable type parameter annotation
+      val allValDefs = constructor.vparamss.flatten
+      val valDefs = allValDefs filterNot { vd =>
+        vd.tpt.tpe.typeSymbol.fullName == "leon.lang.Mutable"
+      }
       if (valDefs.nonEmpty)
         outOfSubsetError(tmpl.pos, "Abstract class with fields are not supported")
 

--- a/src/main/scala/leon/genc/CAST.scala
+++ b/src/main/scala/leon/genc/CAST.scala
@@ -75,6 +75,8 @@ object CAST { // C Abstract Syntax Tree
   case class Primitive(pt: PrimitiveType) extends Type
   case class Pointer(base: Type) extends Type
 
+  case class FunType(ret: Type, params: Seq[Type]) extends Type
+
   case class Struct(id: Id, fields: Seq[Var]) extends DataType {
     require(fields.nonEmpty)
   }

--- a/src/main/scala/leon/genc/CAST.scala
+++ b/src/main/scala/leon/genc/CAST.scala
@@ -134,7 +134,7 @@ object CAST { // C Abstract Syntax Tree
     )
   }
 
-  case class Call(id: Id, args: Seq[Expr]) extends Expr {
+  case class Call(callable: Expr, args: Seq[Expr]) extends Expr {
     require(args forall { _.isValue })
   }
 
@@ -235,7 +235,7 @@ object CAST { // C Abstract Syntax Tree
       val argv = Var(Id("argv"), Pointer(Pointer(Primitive(CharType))))
       val params = argc :: argv :: Nil
 
-      val _mainId = Id("_main")
+      val _mainId = Binding(Id("_main"))
 
       val body = buildBlock(
         if (returnInt) Return(Call(_mainId, Nil)) :: Nil

--- a/src/main/scala/leon/genc/CPrinter.scala
+++ b/src/main/scala/leon/genc/CPrinter.scala
@@ -184,9 +184,14 @@ class CPrinter(val sb: StringBuffer = new StringBuffer) {
     case TypeId(FunType(ret, params), id) => c"$ret (*$id)($params)"
     case TypeId(typ, id) => c"$typ $id"
 
-    case FunSign(Fun(id, returnType, Seq(), _)) => c"${StaticStorage(id)} $returnType $id(void)"
+    case FunSign(Fun(id, FunType(retret, retparamTypes), params, _)) =>
+      c"${StaticStorage(id)} $retret (*$id(${FunSignParams(params)}))(${FunSignParams(retparamTypes)})"
 
-    case FunSign(Fun(id, returnType, params, _)) => c"${StaticStorage(id)} $returnType $id(${nary(params)})"
+    case FunSign(Fun(id, returnType, params, _)) =>
+      c"${StaticStorage(id)} $returnType $id(${FunSignParams(params)})"
+
+    case FunSignParams(Seq()) => c"void"
+    case FunSignParams(params) => c"${nary(params)}"
 
     case FunDecl(f) => c"${FunSign(f)};"
 
@@ -222,6 +227,10 @@ class CPrinter(val sb: StringBuffer = new StringBuffer) {
   private case class StaticStorage(id: Id) extends WrapperTree
   private case class TypeId(typ: Type, id: Id) extends WrapperTree
   private case class FunSign(f: Fun) extends WrapperTree
+
+  // Here, params is expected to be of Type or Var.
+  private case class FunSignParams(params: Seq[Tree]) extends WrapperTree
+
   private case class FunDecl(f: Fun) extends WrapperTree
   private case class TypedefDecl(td: Typedef) extends WrapperTree
   private case class EnumDef(u: Enum) extends WrapperTree

--- a/src/main/scala/leon/genc/ir/ClassLifter.scala
+++ b/src/main/scala/leon/genc/ir/ClassLifter.scala
@@ -97,15 +97,15 @@ final class ClassLifter(val ctx: LeonContext) extends Transformer(NIR, LIR) with
     case FieldAccess(Castable(asa), fieldId) =>
       to.FieldAccess(asa, fieldId) -> env
 
-    case App(fd0, ctx0, args0) =>
-      val fd = rec(fd0)
+    case App(fun0, ctx0, args0) =>
+      val fun = recCallable(fun0)
 
       // Don't pass a casted object but the object itself
       // (this can happen with pattern matching translation).
       val ctx = ctx0 map removeTopCast
       val args = args0 map removeTopCast
 
-      to.App(fd, ctx, args) -> env
+      to.App(fun, ctx, args) -> env
 
     case _ => super.recImpl(e)
   }

--- a/src/main/scala/leon/genc/ir/IR.scala
+++ b/src/main/scala/leon/genc/ir/IR.scala
@@ -59,6 +59,8 @@ private[genc] sealed trait IR { ir =>
     }
 
     override def hashCode: Int = id.hashCode
+
+    def toVal = FunVal(this)
   }
 
   case class ClassDef(id: Id, parent: Option[ClassDef], fields: Seq[ValDef], isAbstract: Boolean) extends Def {
@@ -167,10 +169,11 @@ private[genc] sealed trait IR { ir =>
     // Get the type of the expressions
     final def getType: Type = this match {
       case Binding(vd) => vd.getType
+      case c: Callable => c.typ
       case Block(exprs) => exprs.last.getType
       case Decl(_) => NoType
       case DeclInit(_, _) => NoType
-      case App(fd, _, _) => fd.returnType
+      case App(fun, _, _) => fun.typ.ret
       case Construct(cd, _) => ClassType(cd)
       case ArrayInit(alloc) => alloc.typ
       case FieldAccess(objekt, fieldId) =>
@@ -210,6 +213,26 @@ private[genc] sealed trait IR { ir =>
   // Access a variable
   case class Binding(vd: ValDef) extends Expr
 
+  // Represents either a function definition or a function reference
+  sealed abstract class Callable extends Expr {
+    val id: Id
+    val typ: FunType
+  }
+
+  // References a FunDef directly
+  case class FunVal(fd: FunDef) extends Callable {
+    val id = fd.id
+    val typ = FunType(fd.ctx map { _.getType }, fd.params map { _.getType }, fd.returnType)
+  }
+
+  // Reference any function through a variable of function type
+  case class FunRef(binding: Binding) extends Callable {
+    require(binding.getType.isInstanceOf[FunType])
+
+    val id = binding.vd.id
+    val typ = binding.getType.asInstanceOf[FunType]
+  }
+
   // A non-empty sequence of expressions
   //
   // NOTE Nested Decl & DeclInit expressions have their ValDef available to following expressions in the block.
@@ -228,7 +251,7 @@ private[genc] sealed trait IR { ir =>
   case class DeclInit(vd: ValDef, value: Expr) extends Expr
 
   // Invoke a function with context & regular arguments
-  case class App(fd: FunDef, extra: Seq[Expr], args: Seq[Expr]) extends Expr
+  case class App(fun: Callable, extra: Seq[Expr], args: Seq[Expr]) extends Expr
 
   // Construct an object with the given field values
   case class Construct(cd: ClassDef, args: Seq[Expr]) extends Expr
@@ -316,6 +339,9 @@ private[genc] sealed trait IR { ir =>
     def containsArray: Boolean = this match {
       case PrimitiveType(_) => false
 
+      // Functions currently do not capture anything
+      case FunType(_, _, _) => false
+
       // We do *NOT* answer this question for the whole class hierarchy!
       case ClassType(clazz) => clazz.fields exists { _.getType.containsArray }
 
@@ -332,6 +358,8 @@ private[genc] sealed trait IR { ir =>
 
     def isMutable: Boolean = this match {
       case PrimitiveType(_) => false
+
+      case FunType(_, _, _) => false
 
       // We do answer this question for the whole class hierarchy!
       case ClassType(clazz) => clazz.isHierarchyMutable
@@ -369,6 +397,9 @@ private[genc] sealed trait IR { ir =>
   // Type representing Int32, Boolean, ...
   case class PrimitiveType(primitive: PT) extends Type
 
+  // Type representing a function
+  case class FunType(ctx: Seq[Type], params: Seq[Type], ret: Type) extends Type
+
   // Type representing an abstract or case class, as well as tuples
   case class ClassType(clazz: ClassDef) extends Type
 
@@ -403,6 +434,10 @@ private[genc] sealed trait IR { ir =>
       case UnitType => "unit"
       case StringType => "string"
     }
+    case FunType(ctx, params, ret) =>
+      val ctxRep = ctx map repId mkString "_"
+      val paramsRep = params map repId mkString "_"
+      "function_" + ctx + "_" + params + "_" + repId(ret)
     case ClassType(clazz) => clazz.id
     case ArrayType(base) => "array_" + repId(base)
     case ReferenceType(t) => "ref_" + repId(t)

--- a/src/main/scala/leon/genc/ir/IR.scala
+++ b/src/main/scala/leon/genc/ir/IR.scala
@@ -215,22 +215,18 @@ private[genc] sealed trait IR { ir =>
 
   // Represents either a function definition or a function reference
   sealed abstract class Callable extends Expr {
-    val id: Id
     val typ: FunType
   }
 
   // References a FunDef directly
   case class FunVal(fd: FunDef) extends Callable {
-    val id = fd.id
     val typ = FunType(fd.ctx map { _.getType }, fd.params map { _.getType }, fd.returnType)
   }
 
-  // Reference any function through a variable of function type
-  case class FunRef(binding: Binding) extends Callable {
-    require(binding.getType.isInstanceOf[FunType])
-
-    val id = binding.vd.id
-    val typ = binding.getType.asInstanceOf[FunType]
+  // Reference any function through an expression of function type
+  case class FunRef(e: Expr) extends Callable {
+    require(e.getType.isInstanceOf[FunType])
+    val typ = e.getType.asInstanceOf[FunType]
   }
 
   // A non-empty sequence of expressions

--- a/src/main/scala/leon/genc/ir/IRPrinter.scala
+++ b/src/main/scala/leon/genc/ir/IRPrinter.scala
@@ -85,6 +85,7 @@ final class IRPrinter[S <: IR](val ir: S) {
 
   private def rec(e: Expr)(implicit ptx: Context): String = (e: @unchecked) match {
     case Binding(vd) => "[[ " + vd.id + ": " + rec(vd.getType) + " ]]"
+    case fun: Callable => "@" + fun.id
     case Block(exprs) => "{{ " + (exprs map rec mkString ptx.newLine) + " }}"
     case Decl(vd) => (if (vd.isVar) "var" else "val") + " " + rec(vd) + " // no value"
     case DeclInit(vd, value) => (if (vd.isVar) "var" else "val") + " " + rec(vd) + " = " + rec(value)
@@ -117,6 +118,8 @@ final class IRPrinter[S <: IR](val ir: S) {
 
   private def rec(typ: Type)(implicit ptx: Context): String = (typ: @unchecked) match {
     case PrimitiveType(pt) => pt.toString
+    case FunType(ctx, params, ret) =>
+      "Function[" + (ctx map rec mkString ", ") + "][" + (params map rec mkString ", ") + "]: " + rec(ret)
     case ClassType(clazz) => clazz.id
     case ArrayType(base) => "Array[" + rec(base) + "]"
     case ReferenceType(t) => "Ref[" + rec(t) + "]"

--- a/src/main/scala/leon/genc/ir/IRPrinter.scala
+++ b/src/main/scala/leon/genc/ir/IRPrinter.scala
@@ -85,12 +85,13 @@ final class IRPrinter[S <: IR](val ir: S) {
 
   private def rec(e: Expr)(implicit ptx: Context): String = (e: @unchecked) match {
     case Binding(vd) => "[[ " + vd.id + ": " + rec(vd.getType) + " ]]"
-    case fun: Callable => "@" + fun.id
+    case FunVal(fd) => "@" + fd.id
+    case FunRef(e) => "@{" + rec(e) + "}"
     case Block(exprs) => "{{ " + (exprs map rec mkString ptx.newLine) + " }}"
     case Decl(vd) => (if (vd.isVar) "var" else "val") + " " + rec(vd) + " // no value"
     case DeclInit(vd, value) => (if (vd.isVar) "var" else "val") + " " + rec(vd) + " = " + rec(value)
-    case App(fd, extra, args) =>
-      fd.id + "(<" + (extra map rec mkString ", ") + ">" + (args map rec).mkString(start = ", ", sep = ", ", end = "") + ")"
+    case App(callable, extra, args) =>
+      rec(callable) + "(<" + (extra map rec mkString ", ") + ">" + (args map rec).mkString(start = ", ", sep = ", ", end = "") + ")"
     case Construct(cd, args) => cd.id + "(" + (args map rec mkString ", ") + ")"
     case ArrayInit(alloc) => rec(alloc)
     case FieldAccess(objekt, fieldId) => rec(objekt) + "." + fieldId

--- a/src/main/scala/leon/genc/ir/Operators.scala
+++ b/src/main/scala/leon/genc/ir/Operators.scala
@@ -11,7 +11,7 @@ import PrimitiveTypes._
  */
 private[genc] object Operators {
 
-  // NOTE It is possible to have more than one "From", but not several "To".
+  // NOTE It is possible to have more than one "From" or several "To", but this is not expected!
   //      (It will compile but ungracefully do not what is expected...)
   //
   // NOTE It is also expected that ToIntegral is combined with FromIntegral.
@@ -29,6 +29,7 @@ private[genc] object Operators {
   sealed trait From
   trait FromIntegral extends From
   trait FromLogical extends From
+  trait FromPairOfT extends From // twice the same argument type, includes both FromIntegral and FromLogical
 
   sealed trait To
   trait ToIntegral extends To
@@ -36,7 +37,7 @@ private[genc] object Operators {
 
   trait Integral extends FromIntegral with ToIntegral
   trait Logical extends FromLogical with ToLogical
-  trait Comparative extends FromIntegral with ToLogical
+  trait Ordered extends FromIntegral with ToLogical
 
   abstract class UnaryOperator(val symbol: String, val precedence: Int) extends Operator { this: From with To => }
   abstract class BinaryOperator(val symbol: String, val precedence: Int) extends Operator { this: From with To => }
@@ -48,12 +49,12 @@ private[genc] object Operators {
   case object Div extends BinaryOperator("/", 3) with Integral
   case object Modulo extends BinaryOperator("%", 3) with Integral
 
-  case object LessThan extends BinaryOperator("<", 6) with Comparative
-  case object LessEquals extends BinaryOperator("<=", 6) with Comparative
-  case object GreaterEquals extends BinaryOperator(">=", 6) with Comparative
-  case object GreaterThan extends BinaryOperator(">", 6) with Comparative
-  case object Equals extends BinaryOperator("==", 7) with FromIntegral with FromLogical with ToLogical
-  case object NotEquals extends BinaryOperator("!=", 7) with FromIntegral with FromLogical with ToLogical
+  case object LessThan extends BinaryOperator("<", 6) with Ordered
+  case object LessEquals extends BinaryOperator("<=", 6) with Ordered
+  case object GreaterEquals extends BinaryOperator(">=", 6) with Ordered
+  case object GreaterThan extends BinaryOperator(">", 6) with Ordered
+  case object Equals extends BinaryOperator("==", 7) with FromPairOfT with ToLogical
+  case object NotEquals extends BinaryOperator("!=", 7) with FromPairOfT with ToLogical
 
   case object Not extends UnaryOperator("!", 2) with Logical
   case object And extends BinaryOperator("&&", 11) with Logical

--- a/src/main/scala/leon/genc/ir/Transformer.scala
+++ b/src/main/scala/leon/genc/ir/Transformer.scala
@@ -112,7 +112,7 @@ abstract class Transformer[From <: IR, To <: IR](final val from: From, final val
     case Binding(vd) => to.Binding(rec(vd)) -> env
 
     case FunVal(fd) => to.FunVal(rec(fd)) -> env
-    case FunRef(Binding(vd)) => to.FunRef(to.Binding(rec(vd))) -> env
+    case FunRef(e) => to.FunRef(rec(e)) -> env
 
     // Consider blocks as a sequence of let statements
     case Block(exprs0) =>

--- a/src/main/scala/leon/genc/ir/Visitor.scala
+++ b/src/main/scala/leon/genc/ir/Visitor.scala
@@ -94,7 +94,7 @@ abstract class Visitor[S <: IR](final val ir: S) {
     (e: @unchecked) match {
       case Binding(vd) => rec(vd)
       case FunVal(fd) => rec(fd)
-      case FunRef(b) => rec(b)
+      case FunRef(e) => rec(e)
       case Block(exprs) => exprs foreach rec
       case Decl(vd) => rec(vd)
       case DeclInit(vd, value) => rec(vd); rec(value)

--- a/src/main/scala/leon/genc/ir/Visitor.scala
+++ b/src/main/scala/leon/genc/ir/Visitor.scala
@@ -93,10 +93,12 @@ abstract class Visitor[S <: IR](final val ir: S) {
   private def rec(e: Expr): Unit = {
     (e: @unchecked) match {
       case Binding(vd) => rec(vd)
+      case FunVal(fd) => rec(fd)
+      case FunRef(b) => rec(b)
       case Block(exprs) => exprs foreach rec
       case Decl(vd) => rec(vd)
       case DeclInit(vd, value) => rec(vd); rec(value)
-      case App(fd, extra, args) => rec(fd); extra foreach rec; args foreach rec
+      case App(fun, extra, args) => rec(fun); extra foreach rec; args foreach rec
       case Construct(cd, args) => rec(cd); args foreach rec
       case ArrayInit(alloc) => rec(alloc)
       case FieldAccess(objekt, fieldId) => rec(objekt)
@@ -123,6 +125,7 @@ abstract class Visitor[S <: IR](final val ir: S) {
   private def rec(typ: Type): Unit = {
     (typ: @unchecked) match {
       case PrimitiveType(pt) => ()
+      case FunType(ctx, params, ret) => ((ret +: ctx) ++ params) map rec
       case ClassType(clazz) => rec(clazz)
       case ArrayType(base) => rec(base)
       case ReferenceType(t) => rec(t)

--- a/src/main/scala/leon/genc/phases/IR2CPhase.scala
+++ b/src/main/scala/leon/genc/phases/IR2CPhase.scala
@@ -106,6 +106,7 @@ private class IR2CImpl(val ctx: LeonContext) extends MiniReporter {
 
   private def rec(typ: Type): C.Type = typ match {
     case PrimitiveType(pt) => C.Primitive(pt)
+    case FunType(ctx, params, ret) => C.FunType(params = (ctx ++ params) map rec, ret = rec(ret))
     case ClassType(clazz) => convertClass(clazz) // can be a struct or an enum
     case array @ ArrayType(_) => array2Struct(array)
     case ReferenceType(t) => C.Pointer(rec(t))
@@ -125,6 +126,9 @@ private class IR2CImpl(val ctx: LeonContext) extends MiniReporter {
   // on function definitions, hence no problem with recursive functions.
   private def rec(e: Expr): C.Expr = e match {
     case Binding(vd) => C.Binding(rec(vd.id))
+
+    case FunVal(fd) => C.Binding(rec(fd.id))
+    case FunRef(b) => rec(b)
 
     case Block(exprs) => C.buildBlock(exprs map rec)
 

--- a/src/main/scala/leon/genc/phases/IR2CPhase.scala
+++ b/src/main/scala/leon/genc/phases/IR2CPhase.scala
@@ -128,7 +128,7 @@ private class IR2CImpl(val ctx: LeonContext) extends MiniReporter {
     case Binding(vd) => C.Binding(rec(vd.id))
 
     case FunVal(fd) => C.Binding(rec(fd.id))
-    case FunRef(b) => rec(b)
+    case FunRef(e) => rec(e)
 
     case Block(exprs) => C.buildBlock(exprs map rec)
 
@@ -171,7 +171,7 @@ private class IR2CImpl(val ctx: LeonContext) extends MiniReporter {
 
     case DeclInit(vd, value) => C.DeclInit(rec(vd.id), rec(vd.getType), rec(value))
 
-    case App(fd, extra, args) => C.Call(rec(fd.id), (extra ++ args) map rec)
+    case App(callable, extra, args) => C.Call(rec(callable), (extra ++ args) map rec)
 
     case Construct(cd, args) => constructObject(cd, args) // can be a StructInit or an EnumLiteral
 

--- a/src/main/scala/leon/genc/phases/Scala2IRPhase.scala
+++ b/src/main/scala/leon/genc/phases/Scala2IRPhase.scala
@@ -559,8 +559,8 @@ private class S2IRImpl(val ctx: LeonContext, val ctxDB: FunCtxDB, val deps: Depe
       // Contrary to FunctionInvocation, Application of function-like object do not have to extend their
       // context as no environment variables are allowed to be captured.
       val fun = rec(fun0) match {
-        case b: CIR.Binding if b.getType.isInstanceOf[CIR.FunType] => CIR.FunRef(b)
-        case t => fatalError(s"Expected but got $t of type ${t.getClass}.", fun0.getPos)
+        case e if e.getType.isInstanceOf[CIR.FunType] => CIR.FunRef(e)
+        case e => fatalError(s"Expected a binding but got $e of type ${e.getClass}.", fun0.getPos)
       }
       val args = args0 map rec
 

--- a/src/main/scala/leon/genc/phases/Scala2IRPhase.scala
+++ b/src/main/scala/leon/genc/phases/Scala2IRPhase.scala
@@ -274,7 +274,7 @@ private class S2IRImpl(val ctx: LeonContext, val ctxDB: FunCtxDB, val deps: Depe
 
       case Assert(_, _, body) => scrutRec(body)
 
-      case _: FunctionInvocation | _: CaseClass | _: LetVar | _: Let | _: Tuple | _: IfExpr =>
+      case _: ArraySelect | _: FunctionInvocation | _: CaseClass | _: LetVar | _: Let | _: Tuple | _: IfExpr =>
         withTmp(scrutinee0.getType, scrutinee0, env)
 
       case e => internalError(s"scrutinee = $e of type ${e.getClass} is not supported")

--- a/src/main/scala/leon/purescala/PrettyPrinter.scala
+++ b/src/main/scala/leon/purescala/PrettyPrinter.scala
@@ -95,7 +95,7 @@ class PrettyPrinter(opts: PrinterOptions,
         p"$expr.bigSubstring($start)"
 
       case Let(b, d, e) =>
-        p"""|val $b = $d
+        p"""|val $b: ${b.getType} = $d
             |$e"""
 
       case LetDef(a +: q, body) =>

--- a/src/main/scala/leon/xlang/Expressions.scala
+++ b/src/main/scala/leon/xlang/Expressions.scala
@@ -132,7 +132,7 @@ object Expressions {
     }
 
     def printWith(implicit pctx: PrinterContext) {
-      p"""|var $binder = $value
+      p"""|var $binder : ${binder.getType} = $value
           |$body"""
     }
 

--- a/src/test/resources/regression/genc/invalid/Aliasing1.scala
+++ b/src/test/resources/regression/genc/invalid/Aliasing1.scala
@@ -2,7 +2,7 @@
 
 import leon.annotation.extern
 
-object Aliasing {
+object Aliasing1 {
 
   case class MutableInteger(var x: Int)
 

--- a/src/test/resources/regression/genc/invalid/Aliasing2.scala
+++ b/src/test/resources/regression/genc/invalid/Aliasing2.scala
@@ -1,0 +1,33 @@
+/* Copyright 2009-2016 EPFL, Lausanne */
+
+import leon.annotation.extern
+
+object Aliasing2 {
+
+  case class Counter(var i: Int)
+
+  def foo(t: (Int, Counter)) {
+    val (x, c) = t // this should probably be illegal from an aliasing point of view.
+    c.i += x
+
+    // Three example of code that might be legal, but are currently not supported:
+    // t._2.i += t._1 // illegal, but why?
+    // t._2.i = t._1 // illegal as well, but why?
+    // t._2.i = 0 // still illegal, but why?
+    // Note that these three example do not attempt to make the whole program be correct.
+  }
+
+  def _main(): Int = {
+    val c = Counter(58)
+    foo((42, c)) // here is the issue with GenC: `c` is copied.
+
+    leon.io.StdOut.println(c.i) // Prints 100 on the JVM
+
+    c.i - 100
+  } ensuring { _ == 0 }
+
+  @extern
+  def main(args: Array[String]): Unit = _main()
+
+}
+

--- a/src/test/resources/regression/genc/invalid/Aliasing3.scala
+++ b/src/test/resources/regression/genc/invalid/Aliasing3.scala
@@ -1,0 +1,31 @@
+/* Copyright 2009-2016 EPFL, Lausanne */
+
+import leon.annotation.extern
+
+object Aliasing3 {
+
+  case class A(var x: Int)
+  case class B(a: A, y: Int)
+
+  def updateB(b1: B, b2: B): Unit = {
+    b1.a.x = 42
+    b2.a.x = 41
+  }
+
+  def update(a1: A, a2: A, y: Int): Unit = {
+    updateB(B(a2, y), B(a1, y)) // here is the issue with GenC
+  } ensuring(_ => a2.x == 42 && a1.x == 41)
+
+  def _main(): Int = {
+    val a1 = A(11)
+    val a2 = A(22)
+
+    update(a1, a2, -1)
+
+    a2.x - a1.x - 1
+  } ensuring { _ == 0 }
+
+  @extern
+  def main(args: Array[String]): Unit = _main()
+}
+

--- a/src/test/resources/regression/genc/invalid/Functions1.scala
+++ b/src/test/resources/regression/genc/invalid/Functions1.scala
@@ -1,0 +1,21 @@
+/* Copyright 2009-2016 EPFL, Lausanne */
+
+import leon.annotation._
+import leon.lang._
+
+object Functions1 {
+
+  def square(x: Int): Int = x * x
+
+  def apply(fun: Int => Int, x: Int): Int = fun(x)
+
+  @extern
+  def main(args: Array[String]): Unit = _main()
+
+  def _main(): Int = {
+    val y = 5
+    apply({ x: Int => square(y) }, 2) // Not allowed: capturing y
+  }
+
+}
+

--- a/src/test/resources/regression/genc/invalid/Functions2.scala
+++ b/src/test/resources/regression/genc/invalid/Functions2.scala
@@ -1,0 +1,18 @@
+/* Copyright 2009-2016 EPFL, Lausanne */
+
+import leon.annotation._
+import leon.lang._
+
+object Functions2 {
+
+  def apply(fun: Int => Int, x: Int): Int = fun(x)
+
+  @extern
+  def main(args: Array[String]): Unit = _main()
+
+  def _main(): Int = {
+    apply({ x: Int => x - x }, 2) // Not allowed: not a named function
+  }
+
+}
+

--- a/src/test/resources/regression/genc/invalid/Functions3.scala
+++ b/src/test/resources/regression/genc/invalid/Functions3.scala
@@ -1,0 +1,22 @@
+/* Copyright 2009-2016 EPFL, Lausanne */
+
+import leon.annotation._
+import leon.lang._
+
+object Functions3 {
+
+  def apply(fun: Int => Int, x: Int): Int = fun(x)
+
+  @extern
+  def main(args: Array[String]): Unit = _main()
+
+  def _main(): Int = {
+    var y = 5
+    def fun(x: Int) = x + y
+    y = -2
+
+    apply(fun, 2) // Not allowed: reference to a function capturing its env.
+  }
+
+}
+

--- a/src/test/resources/regression/genc/unverified/PatternMatching1.scala
+++ b/src/test/resources/regression/genc/unverified/PatternMatching1.scala
@@ -1,0 +1,33 @@
+/* Copyright 2009-2016 EPFL, Lausanne */
+
+import leon.annotation._
+import leon.lang._
+
+// This test is "unverified" because side-effect in pat-mat expression
+// is not well supported by the verification system.
+object PatternMatching1 {
+
+  case class Wrapper(var x: Int)
+
+  def _main(): Int = {
+    var c = 1
+
+    def get0(): Int = {
+      c -= 1
+      0
+    }
+
+    val array = Array(Wrapper(42))
+    array(get0()) match {
+      case w if w.x == 42 => w.x = 0
+      case w => w.x = -1
+    }
+
+    array(0).x + c
+  } ensuring { _ == 0 }
+
+  @extern
+  def main(args: Array[String]): Unit = _main()
+
+}
+

--- a/src/test/resources/regression/genc/valid/Functions1.scala
+++ b/src/test/resources/regression/genc/valid/Functions1.scala
@@ -1,0 +1,23 @@
+/* Copyright 2009-2017 EPFL, Lausanne */
+
+import leon.annotation._
+import leon.lang._
+
+object Functions1 {
+
+  def square(x: Int): Int = x * x
+  def double(x: Int): Int = x + x
+
+  def apply(fun: Int => Int, x: Int): Int = fun(x)
+
+  @extern
+  def main(args: Array[String]): Unit = _main()
+
+  def _main(): Int = {
+    val fun = double _
+    apply(square, 2) - apply(fun, 2)
+  } ensuring { _ == 0 }
+
+}
+
+

--- a/src/test/resources/regression/genc/valid/Functions2.scala
+++ b/src/test/resources/regression/genc/valid/Functions2.scala
@@ -1,0 +1,23 @@
+/* Copyright 2009-2017 EPFL, Lausanne */
+
+import leon.annotation._
+import leon.lang._
+
+object Functions2 {
+
+  def square(x: Int): Int = x * x
+
+  def getSquare: Int => Int = square _
+
+  def apply(fun: Int => Int, x: Int): Int = fun(x)
+
+  @extern
+  def main(args: Array[String]): Unit = _main()
+
+  def _main(): Int = {
+    apply(getSquare, 0)
+  } ensuring { _ == 0 }
+
+}
+
+

--- a/src/test/resources/regression/genc/valid/Functions3.scala
+++ b/src/test/resources/regression/genc/valid/Functions3.scala
@@ -1,0 +1,23 @@
+/* Copyright 2009-2017 EPFL, Lausanne */
+
+import leon.annotation._
+import leon.lang._
+
+object Functions3 {
+
+  def square(x: Int): Int = x * x
+
+  def id(f: Int => Int): Int => Int = f
+
+  def apply(fun: Int => Int, x: Int): Int = fun(x)
+
+  @extern
+  def main(args: Array[String]): Unit = _main()
+
+  def _main(): Int = {
+    apply(id(square), 0)
+  } ensuring { _ == 0 }
+
+}
+
+

--- a/src/test/resources/regression/genc/valid/Functions4.scala
+++ b/src/test/resources/regression/genc/valid/Functions4.scala
@@ -1,0 +1,24 @@
+/* Copyright 2009-2017 EPFL, Lausanne */
+
+import leon.annotation._
+import leon.lang._
+
+object Functions4 {
+
+  case class FunWrapper(fun: Int => Int) {
+    def run(x: Int): Int = fun(x)
+  }
+
+  def square(x: Int): Int = x * x
+
+  @extern
+  def main(args: Array[String]): Unit = _main()
+
+  def _main(): Int = {
+    val w = FunWrapper(square)
+    w.run(4) - 16
+  } ensuring { _ == 0 }
+
+}
+
+

--- a/src/test/resources/regression/genc/valid/Functions5.scala
+++ b/src/test/resources/regression/genc/valid/Functions5.scala
@@ -1,0 +1,27 @@
+/* Copyright 2009-2017 EPFL, Lausanne */
+
+import leon.annotation._
+import leon.lang._
+
+object Functions5 {
+
+  case class FunWrapper(fun: Int => Int) {
+    def run(x: Int): Int = id(fun)(x)
+  }
+
+  def id(f: Int => Int) = f
+
+  def square(x: Int): Int = x * x
+
+  @extern
+  def main(args: Array[String]): Unit = _main()
+
+  def _main(): Int = {
+    val w = FunWrapper(square)
+    val v = FunWrapper(id(w.fun))
+    v.run(4) - 16
+  } ensuring { _ == 0 }
+
+}
+
+

--- a/src/test/resources/regression/genc/valid/Functions6.scala
+++ b/src/test/resources/regression/genc/valid/Functions6.scala
@@ -1,0 +1,27 @@
+/* Copyright 2009-2017 EPFL, Lausanne */
+
+import leon.annotation._
+import leon.lang._
+
+object Functions6 {
+
+  case class M(var x: Int)
+
+  def square(m: M): Unit = { m.x *= m.x }
+
+  def apply(fun: M => Unit, m: M): Unit = fun(m)
+
+  @extern
+  def main(args: Array[String]): Unit = _main()
+
+  def _main(): Int = {
+    val m = M(4)
+
+    apply(square, m)
+
+    m.x - 16
+  } ensuring { _ == 0 }
+
+}
+
+

--- a/src/test/resources/regression/genc/valid/Functions7.scala
+++ b/src/test/resources/regression/genc/valid/Functions7.scala
@@ -1,0 +1,31 @@
+/* Copyright 2009-2017 EPFL, Lausanne */
+
+import leon.annotation._
+import leon.lang._
+
+object Functions7 {
+
+  def index(xs: Array[Int]): Unit = {
+    var i = 0
+    (while (i < xs.length) {
+      xs(i) = i + 1
+      i += 1
+    }) invariant (0 <= i && i <= xs.length)
+  }
+
+  def apply(fun: Array[Int] => Unit, xs: Array[Int]): Unit = fun(xs)
+
+  @extern
+  def main(args: Array[String]): Unit = _main()
+
+  def _main(): Int = {
+    val xs = Array(-1, -1, -1)
+
+    apply(index, xs)
+
+    xs(2) - xs(1) - xs(0)
+  } ensuring { _ == 0 }
+
+}
+
+

--- a/src/test/resources/regression/genc/valid/Functions8.scala
+++ b/src/test/resources/regression/genc/valid/Functions8.scala
@@ -1,0 +1,30 @@
+/* Copyright 2009-2017 EPFL, Lausanne */
+
+import leon.annotation._
+import leon.lang._
+
+object Functions8 {
+
+  case class M(var x: Int)
+
+  def mutatecopy(m: M) = {
+    val copy = M(m.x)
+    m.x += 1
+    copy
+  }
+
+  def apply(fun: M => M, m: M): M = fun(m)
+
+  @extern
+  def main(args: Array[String]): Unit = _main()
+
+  def _main(): Int = {
+    val m1 = M(1)
+    val m2 = apply(mutatecopy, m1)
+
+    m1.x - m2.x - 1
+  } ensuring { _ == 0 }
+
+}
+
+

--- a/src/test/resources/regression/genc/valid/OperatorEquals1.scala
+++ b/src/test/resources/regression/genc/valid/OperatorEquals1.scala
@@ -1,0 +1,21 @@
+/* Copyright 2009-2016 EPFL, Lausanne */
+
+import leon.annotation._
+import leon.lang._
+
+object OperatorEquals1 {
+
+  case class T(x: Int)
+
+  def _main(): Int = {
+    val x = T(42)
+    val y = T(42)
+    if (x == y) 0
+    else 1
+  } ensuring { _ == 0 }
+
+  @extern
+  def main(args: Array[String]): Unit = _main()
+
+}
+

--- a/src/test/resources/regression/genc/valid/OperatorEquals2.scala
+++ b/src/test/resources/regression/genc/valid/OperatorEquals2.scala
@@ -3,17 +3,20 @@
 import leon.annotation._
 import leon.lang._
 
-object OperatorEquals {
+object OperatorEquals2 {
 
-  case class T(x: Int)
+  case class T(var x: Int)
 
   def _main(): Int = {
     val x = T(42)
     val y = T(42)
-    // Custom operator `==` not supported
-    if (x == y) 0
+    if (x == y) {
+      x.x = 0
+      if (x == y) 2
+      else 0
+    }
     else 1
-  }
+  } ensuring { _ == 0 }
 
   @extern
   def main(args: Array[String]): Unit = _main()

--- a/src/test/resources/regression/genc/valid/OperatorEquals3.scala
+++ b/src/test/resources/regression/genc/valid/OperatorEquals3.scala
@@ -1,0 +1,33 @@
+/* Copyright 2009-2016 EPFL, Lausanne */
+
+import leon.annotation._
+import leon.lang._
+
+object OperatorEquals3 {
+
+  case class A(b: B)
+  case class B(t1: T, t2: T)
+  case class T(var x: Int)
+
+  def foo = A(B(T(0), T(1)))
+  def bar = A(B(T(1), T(0)))
+
+  def _main(): Int = {
+    val a1 = foo
+    val a2 = foo
+    val b1 = bar
+
+    if (a1 == foo && a2 == a1) {
+      if (b1 == bar) {
+        if (b1 == a1) 3
+        else if (b1 != a1) 0
+        else 4
+      } else 2
+    } else 1
+  } ensuring { _ == 0 }
+
+  @extern
+  def main(args: Array[String]): Unit = _main()
+
+}
+

--- a/src/test/resources/regression/genc/valid/OperatorEquals4.scala
+++ b/src/test/resources/regression/genc/valid/OperatorEquals4.scala
@@ -1,0 +1,32 @@
+/* Copyright 2009-2016 EPFL, Lausanne */
+
+import leon.annotation._
+import leon.lang._
+
+object OperatorEquals4 {
+
+  abstract class Top
+  case class ChildA(x: Int) extends Top
+  case class ChildB(y: Boolean) extends Top
+
+  def foo = ChildA(42)
+  def bar = ChildB(true)
+
+  def factory(zero: Int): Top = if (zero == 0) foo else bar
+
+  def _main(): Int = {
+    val a = factory(0)
+    val b = factory(1)
+
+    if (a == b) {
+      if (a != b) 2
+      else 1
+    } else 0
+
+  } ensuring { _ == 0 }
+
+  @extern
+  def main(args: Array[String]): Unit = _main()
+
+}
+

--- a/src/test/resources/regression/genc/valid/OperatorEquals5.scala
+++ b/src/test/resources/regression/genc/valid/OperatorEquals5.scala
@@ -1,0 +1,37 @@
+/* Copyright 2009-2016 EPFL, Lausanne */
+
+import leon.annotation._
+import leon.lang._
+
+object OperatorEquals5 {
+
+  abstract class Top
+  case class ChildA(var x: Int) extends Top
+  case class ChildB(y: Boolean) extends Top
+
+  def foo(x: Int) = ChildA(x)
+  def bar = ChildB(true)
+
+  def factory(zero: Int): Top = if (zero == 0) bar else foo(zero)
+
+  def _main(): Int = {
+    val a = factory(0)
+    val b = factory(1)
+    val c = factory(2)
+
+    if (a == b || a == c) 1
+    else if (!(a != b && a != c)) 2
+    else if (b == c) 3
+    else {
+      b.asInstanceOf[ChildA].x = 2
+      if (b == c && !(b != c)) 0
+      else 4
+    }
+
+  } ensuring { _ == 0 }
+
+  @extern
+  def main(args: Array[String]): Unit = _main()
+
+}
+

--- a/src/test/resources/regression/genc/valid/OperatorEquals6.scala
+++ b/src/test/resources/regression/genc/valid/OperatorEquals6.scala
@@ -1,0 +1,27 @@
+/* Copyright 2009-2016 EPFL, Lausanne */
+
+import leon.annotation._
+import leon.lang._
+
+object OperatorEquals6 {
+
+  case class T(var x: Int)
+
+  def test(t1: T, t2: T) = t1 == t2
+
+  def _main(): Int = {
+    val x = T(42)
+    val y = T(42)
+    if (test(x, y)) {
+      x.x = 0
+      if (test(x, y)) 2
+      else 0
+    }
+    else 1
+  } ensuring { _ == 0 }
+
+  @extern
+  def main(args: Array[String]): Unit = _main()
+
+}
+

--- a/src/test/resources/regression/genc/valid/OperatorEquals7.scala
+++ b/src/test/resources/regression/genc/valid/OperatorEquals7.scala
@@ -1,0 +1,23 @@
+/* Copyright 2009-2016 EPFL, Lausanne */
+
+import leon.annotation._
+import leon.lang._
+
+object OperatorEquals7 {
+
+  def test(a: String, b: String) = a == b
+
+  def _main(): Int = {
+    val str1 = "Hello"
+    val str2 = "GenC"
+    if (test(str1, str1) && test(str2, str2)) {
+      if (test(str1, str2)) 1
+      else 0
+    } else 2
+  } ensuring { _ == 0 }
+
+  @extern
+  def main(args: Array[String]): Unit = _main()
+
+}
+

--- a/src/test/resources/regression/genc/valid/OperatorEquals8.scala
+++ b/src/test/resources/regression/genc/valid/OperatorEquals8.scala
@@ -1,0 +1,25 @@
+/* Copyright 2009-2016 EPFL, Lausanne */
+
+import leon.annotation._
+import leon.lang._
+
+object OperatorEquals8 {
+
+  case class T(var x: Int)
+
+  def test(t2: T) = {
+    val t1 = T(0)
+    t1 == t2
+  }
+
+  def _main(): Int = {
+    val t2 = T(0)
+    if (test(t2)) 0
+    else 1
+  } ensuring { _ == 0 }
+
+  @extern
+  def main(args: Array[String]): Unit = _main()
+
+}
+

--- a/src/test/resources/regression/genc/valid/PatternMatching7.scala
+++ b/src/test/resources/regression/genc/valid/PatternMatching7.scala
@@ -1,0 +1,22 @@
+/* Copyright 2009-2016 EPFL, Lausanne */
+
+import leon.annotation._
+import leon.lang._
+
+object PatternMatching7 {
+
+  case class Wrapper(var x: Int)
+
+  def _main(): Int = {
+    val array = Array(Wrapper(42))
+    array(0) match {
+      case w => w.x = 0
+    }
+    array(0).x
+  } ensuring { _ == 0 }
+
+  @extern
+  def main(args: Array[String]): Unit = _main()
+
+}
+

--- a/src/test/resources/regression/genc/valid/PatternMatching8.scala
+++ b/src/test/resources/regression/genc/valid/PatternMatching8.scala
@@ -1,0 +1,24 @@
+/* Copyright 2009-2016 EPFL, Lausanne */
+
+import leon.annotation._
+import leon.lang._
+
+object PatternMatching8 {
+
+  case class Wrapper(var x: Int)
+
+  def _main(): Int = {
+    val array = Array(Wrapper(42))
+    array(get0()) match {
+      case w => w.x = 0
+    }
+    array(0).x
+  } ensuring { _ == 0 }
+
+  def get0(): Int = 0
+
+  @extern
+  def main(args: Array[String]): Unit = _main()
+
+}
+

--- a/src/test/resources/regression/genc/valid/PatternMatching9.scala
+++ b/src/test/resources/regression/genc/valid/PatternMatching9.scala
@@ -3,9 +3,7 @@
 import leon.annotation._
 import leon.lang._
 
-// This test is "unverified" because side-effect in pat-mat expression
-// is not well supported by the verification system.
-object PatternMatching1 {
+object PatternMatching9 {
 
   case class Wrapper(var x: Int)
 


### PR DESCRIPTION
 - Higher order functions are now supported, as long as they do not capture their environment.
 - `==` and `!=` on classes is handled decently by GenC, producing `equals` functions.
 - The form of aliasing that GenC cannot support at the moment are now properly rejected instead of producing inequivalent code.
 - Pattern matching on array access is now supported.
 - Workaround some bug with identifiers -- this applies to GenC only, not the verification part of Leon. (Such bug doesn't exist in stainless.)
 - Ignore more implicit evidences for mutable types annotations when extracting the AST.