### PR TITLE
Use a more portable shebang

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -102,7 +102,9 @@ script := {
       s.log.info("Generating '"+f.getName+"' script ("+(if(is64) "64b" else "32b")+")...")
     }
     val paths = (res.getAbsolutePath +: out.getAbsolutePath +: cps.map(_.data.absolutePath)).mkString(System.getProperty("path.separator"))
-    IO.write(f, s"""|#!/bin/bash --posix
+    IO.write(f, s"""|#!/usr/bin/env bash
+                    |
+                    | set -o posix
                     |
                     |SCALACLASSPATH="$paths"
                     |


### PR DESCRIPTION
Since the *bash* binary is [not always located in */bin*][0], the *leon*
script doesn't always run.

This change makes the script more portable, so leon will run on more
systems.

[0]: https://stackoverflow.com/questions/21612980